### PR TITLE
Issue1355

### DIFF
--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -806,6 +806,130 @@ NOTE: The same factory can be used to create both `single message` and `batch` c
 
 IMPORTANT: In case the same factory is shared by both delivery methods, any supplied `ErrorHandler`, `MessageInterceptor` or `MessageListener` should implement the proper methods.
 
+==== Automatic Batching with AWS SDK
+
+Spring Cloud AWS supports automatic message batching using AWS SDK's `SqsAsyncBatchManager`. This feature optimizes SQS operations by automatically batching requests under the hood to improve performance and reduce AWS API calls.
+
+IMPORTANT: This is different from the <<Batch Processing,Batch Processing>> feature described above. Batch Processing refers to processing multiple messages in a single listener method call, while Automatic Batching refers to the AWS SDK automatically combining multiple SQS API calls into batched requests for efficiency.
+
+===== Enabling Automatic Batching
+
+To enable automatic batching, set the following property:
+
+[source,properties]
+----
+spring.cloud.aws.sqs.batch.enabled=true
+----
+
+When enabled, Spring Cloud AWS will automatically wrap the `SqsAsyncClient` with a `BatchingSqsClientAdapter` that uses `SqsAsyncBatchManager` internally.
+
+===== Configuration Properties
+
+The following properties can be used to configure the batching behavior:
+
+[source,properties]
+----
+# Enable automatic batching (default: false)
+spring.cloud.aws.sqs.batch.enabled=true
+
+# Maximum number of messages in a batch (default: AWS SDK default, max: 10)
+spring.cloud.aws.sqs.batch.max-number-of-messages=10
+
+# Frequency at which batched requests are sent (default: AWS SDK default)
+spring.cloud.aws.sqs.batch.send-batch-frequency=PT0.2S
+
+# Visibility timeout for received messages (default: queue default)
+spring.cloud.aws.sqs.batch.visibility-timeout=PT30S
+
+# Wait time for receiveMessage requests (default: AWS SDK default)
+spring.cloud.aws.sqs.batch.wait-time-seconds=PT5S
+
+# System attributes to request for receiveMessage calls
+spring.cloud.aws.sqs.batch.system-attribute-names=SentTimestamp,ApproximateReceiveCount
+
+# Message attributes to request for receiveMessage calls
+spring.cloud.aws.sqs.batch.attribute-names=MessageGroupId,MessageDeduplicationId
+----
+
+===== Important Considerations
+
+WARNING: When using automatic batching, operations are processed asynchronously by the AWS SDK. This means that a method call may return successfully, but the actual request to AWS SQS might fail later during the batching process. This can result in **false positives** where operations appear to succeed locally but fail during transmission.
+
+Applications should:
+
+- **Always handle the returned `CompletableFuture`** to detect actual transmission errors
+- **Implement appropriate error handling and monitoring** to detect delayed failures
+- **Consider retry mechanisms** for critical operations
+
+IMPORTANT: **Batch Manager Bypass**: The AWS SDK batch manager will bypass batching and send regular asynchronous requests when `receiveMessage` is called with any of the following parameters:
+
+- `messageAttributeNames`
+- `messageSystemAttributeNames` 
+- `messageSystemAttributeNamesWithStrings` (not used in Spring Cloud AWS `ReceiveMessageRequest`)
+- `overrideConfiguration` (not used in Spring Cloud AWS `ReceiveMessageRequest`)
+
+When these parameters are used, the performance benefits of batching are lost for those specific requests. 
+
+**Note**: When using Spring Cloud AWS's automatic batching feature, `SqsTemplate` automatically excludes `messageAttributeNames` and `messageSystemAttributeNames` from individual `receiveMessage` requests to maintain batching efficiency. These attributes should be configured globally in the batch configuration instead:
+
+[source,properties]
+----
+# Configure globally for batched requests
+spring.cloud.aws.sqs.batch.system-attribute-names=SentTimestamp,ApproximateReceiveCount
+spring.cloud.aws.sqs.batch.attribute-names=MessageGroupId,MessageDeduplicationId
+----
+
+If you need to use different attribute configurations per request, consider disabling automatic batching and using the standard `SqsAsyncClient` instead.
+
+Example of proper error handling:
+
+[source,java]
+----
+@Service
+public class MessageService {
+    
+    private final SqsTemplate sqsTemplate;
+    
+    public MessageService(SqsTemplate sqsTemplate) {
+        this.sqsTemplate = sqsTemplate;
+    }
+    
+    public void sendMessage(String queueName, String message) {
+        CompletableFuture<SendResult<String>> future = sqsTemplate.sendAsync(queueName, message);
+        
+        future.whenComplete((result, throwable) -> {
+            if (throwable != null) {
+                // Handle actual transmission error
+                log.error("Failed to send message to queue {}: {}", queueName, throwable.getMessage());
+                // Implement retry or alternative handling logic
+            } else {
+                // Message sent successfully
+                log.info("Message sent successfully with ID: {}", result.messageId());
+            }
+        });
+    }
+}
+----
+
+===== Performance Benefits
+
+Automatic batching provides several benefits:
+
+- **Reduced API calls**: Multiple operations are combined into single API calls
+- **Lower costs**: Fewer API calls result in reduced AWS charges
+- **Improved throughput**: Batching reduces network overhead and latency
+- **Better resource utilization**: More efficient use of network and AWS resources
+
+===== Compatibility
+
+Automatic batching is compatible with:
+
+- `SqsTemplate` for sending and receiving messages
+- `@SqsListener` methods for message processing
+- Both standard and FIFO queues
+- All message conversion and error handling features
+
+The batching is transparent to application code - existing `SqsTemplate` and `@SqsListener` code continues to work without changes.
 
 ==== Container Options
 
@@ -876,6 +1000,13 @@ The Spring Boot Starter for SQS provides the following auto-configuration proper
 | <<maxDelayBetweenPolls, `spring.cloud.aws.sqs.listener.max-delay-between-polls`>> | Maximum amount of time to wait between polls. | No | 10 seconds
 | `spring.cloud.aws.sqs.queue-not-found-strategy`  | The strategy to be used by SqsTemplate and SqsListeners when a queue does not exist. | No | CREATE
 | `spring.cloud.aws.sqs.observation-enabled` | Enables observability support for SQS operations. | No | false
+| `spring.cloud.aws.sqs.batch.enabled` | Enables automatic SQS batching using AWS SDK's SqsAsyncBatchManager. | No | `false`
+| `spring.cloud.aws.sqs.batch.max-number-of-messages` | Maximum number of messages in a batch (max: 10). | No | AWS SDK default
+| `spring.cloud.aws.sqs.batch.send-batch-frequency` | Frequency at which batched requests are sent. | No | AWS SDK default
+| `spring.cloud.aws.sqs.batch.visibility-timeout` | Visibility timeout for received messages in batch. | No | Queue default
+| `spring.cloud.aws.sqs.batch.wait-time-seconds` | Wait time for receiveMessage requests in batch. | No | AWS SDK default
+| `spring.cloud.aws.sqs.batch.system-attribute-names` | System attributes to request for receiveMessage calls. | No | None
+| `spring.cloud.aws.sqs.batch.attribute-names` | Message attributes to request for receiveMessage calls. | No | None
 |===
 
 

--- a/docs/src/main/asciidoc/sqs.adoc
+++ b/docs/src/main/asciidoc/sqs.adoc
@@ -1007,6 +1007,7 @@ The Spring Boot Starter for SQS provides the following auto-configuration proper
 | `spring.cloud.aws.sqs.batch.wait-time-seconds` | Wait time for receiveMessage requests in batch. | No | AWS SDK default
 | `spring.cloud.aws.sqs.batch.system-attribute-names` | System attributes to request for receiveMessage calls. | No | None
 | `spring.cloud.aws.sqs.batch.attribute-names` | Message attributes to request for receiveMessage calls. | No | None
+| `spring.cloud.aws.sqs.batch.scheduled-executor-pool-size` | Size of the scheduled thread pool for batching operations. | No | 5
 |===
 
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfiguration.java
@@ -52,6 +52,8 @@ import software.amazon.awssdk.services.sqs.batchmanager.BatchOverrideConfigurati
 import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
 import software.amazon.awssdk.services.sqs.model.Message;
 
+import java.util.concurrent.Executors;
+
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for SQS integration.
  *
@@ -98,6 +100,7 @@ public class SqsAutoConfiguration {
 	private SqsAsyncBatchManager createBatchManager(SqsAsyncClient sqsAsyncClient) {
 		return SqsAsyncBatchManager.builder()
 			.client(sqsAsyncClient)
+            .scheduledExecutor(Executors.newScheduledThreadPool(5))
 			.overrideConfiguration(this::configurationProperties)
 			.build();
 	}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -206,9 +206,9 @@ public class SqsProperties extends AwsClientProperties {
 			return enabled;
 		}
 
-		public void setEnabled(Boolean enabled) {
-			this.enabled = enabled;
-		}
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
 
 		@Nullable
 		public Integer getMaxNumberOfMessages() {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -155,10 +155,30 @@ public class SqsProperties extends AwsClientProperties {
 
 	}
 
+	/**
+	 * Configuration properties for SQS automatic batching using AWS SDK's {@code SqsAsyncBatchManager}.
+	 * 
+	 * <p>Automatic batching improves performance and reduces costs by combining multiple SQS requests
+	 * into fewer AWS API calls. When enabled, Spring Cloud AWS will use a {@code BatchingSqsClientAdapter}
+	 * that wraps the standard {@code SqsAsyncClient} with batching capabilities.
+	 * 
+	 * <p><strong>Important:</strong> Batched operations are processed asynchronously, which may result
+	 * in false positives where method calls appear to succeed locally but fail during actual transmission
+	 * to AWS. Applications should handle the returned {@code CompletableFuture} objects to detect
+	 * actual transmission errors.
+	 * 
+	 * @since 3.2
+	 */
 	public static class Batch {
 
 		/**
 		 * Enables SQS automatic batching using AWS SDK's SqsAsyncBatchManager.
+		 * 
+		 * <p>When set to {@code true}, the {@code SqsAsyncClient} bean will be wrapped
+		 * with a {@code BatchingSqsClientAdapter} that automatically batches requests
+		 * to improve performance and reduce AWS API calls.
+		 * 
+		 * <p>Default is {@code false}.
 		 */
 		private boolean enabled = false;
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -17,9 +17,12 @@ package io.awspring.cloud.autoconfigure.sqs;
 
 import io.awspring.cloud.autoconfigure.AwsClientProperties;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
-import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.lang.Nullable;
+import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
+
+import java.time.Duration;
+import java.util.List;
 
 /**
  * Properties related to AWS SQS.
@@ -79,8 +82,9 @@ public class SqsProperties extends AwsClientProperties {
 	public static class Listener {
 
 		/**
-		 * The maximum concurrent messages that can be processed simultaneously for each queue. Note that if
-		 * acknowledgement batching is being used, the actual maximum number of messages inflight might be higher.
+		 * The maximum concurrent messages that can be processed simultaneously for each
+		 * queue. Note that if acknowledgement batching is being used, the actual maximum
+		 * number of messages inflight might be higher.
 		 */
 		@Nullable
 		private Integer maxConcurrentMessages;
@@ -138,6 +142,93 @@ public class SqsProperties extends AwsClientProperties {
 		public void setMaxDelayBetweenPolls(Duration maxDelayBetweenPolls) {
 			this.maxDelayBetweenPolls = maxDelayBetweenPolls;
 		}
+
+	}
+
+	public static class Batch {
+
+		/**
+		 * The maximum number of messages that can be processed in a single batch. The
+		 * maximum is 10.
+		 */
+		private Integer maxNumberOfMessages;
+
+		/**
+		 * The frequency at which requests are sent to SQS when processing messages in a
+		 * batch.
+		 */
+		private Duration sendBatchFrequency;
+
+		/**
+		 * The visibility timeout to set for messages received in a batch. If unset, the
+		 * queue default is used.
+		 */
+		private Duration visibilityTimeout;
+
+		/**
+		 * The minimum wait duration for a receiveMessage request in a batch. To avoid
+		 * unnecessary CPU usage, do not set this value to 0.
+		 */
+		private Duration waitTimeSeconds;
+
+		/**
+		 * The list of system attribute names to request for receiveMessage calls.
+		 */
+		private List<MessageSystemAttributeName> systemAttributeNames;
+
+		/**
+		 * The list of attribute names to request for receiveMessage calls.
+		 */
+		private List<String> attributeNames;
+
+		public Integer getMaxNumberOfMessages() {
+			return maxNumberOfMessages;
+		}
+
+		public void setMaxNumberOfMessages(Integer maxNumberOfMessages) {
+			this.maxNumberOfMessages = maxNumberOfMessages;
+		}
+
+		public Duration getSendBatchFrequency() {
+			return sendBatchFrequency;
+		}
+
+		public void setSendBatchFrequency(Duration sendBatchFrequency) {
+			this.sendBatchFrequency = sendBatchFrequency;
+		}
+
+		public Duration getVisibilityTimeout() {
+			return visibilityTimeout;
+		}
+
+		public void setVisibilityTimeout(Duration visibilityTimeout) {
+			this.visibilityTimeout = visibilityTimeout;
+		}
+
+		public Duration getWaitTimeSeconds() {
+			return waitTimeSeconds;
+		}
+
+		public void setWaitTimeSeconds(Duration waitTimeSeconds) {
+			this.waitTimeSeconds = waitTimeSeconds;
+		}
+
+		public List<MessageSystemAttributeName> getSystemAttributeNames() {
+			return systemAttributeNames;
+		}
+
+		public void setSystemAttributeNames(List<MessageSystemAttributeName> systemAttributeNames) {
+			this.systemAttributeNames = systemAttributeNames;
+		}
+
+		public List<String> getAttributeNames() {
+			return attributeNames;
+		}
+
+		public void setAttributeNames(List<String> attributeNames) {
+			this.attributeNames = attributeNames;
+		}
+
 	}
 
 }

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -41,12 +41,22 @@ public class SqsProperties extends AwsClientProperties {
 
 	private Listener listener = new Listener();
 
+	private Batch batch = new Batch();
+
 	public Listener getListener() {
 		return this.listener;
 	}
 
 	public void setListener(Listener listener) {
 		this.listener = listener;
+	}
+
+	public Batch getBatch() {
+		return batch;
+	}
+
+	public void setBatch(Batch batch) {
+		this.batch = batch;
 	}
 
 	@Nullable
@@ -148,39 +158,60 @@ public class SqsProperties extends AwsClientProperties {
 	public static class Batch {
 
 		/**
+		 * Enables SQS automatic batching using AWS SDK's SqsAsyncBatchManager.
+		 */
+		private boolean enabled = false;
+
+		/**
 		 * The maximum number of messages that can be processed in a single batch. The
 		 * maximum is 10.
 		 */
+		@Nullable
 		private Integer maxNumberOfMessages;
 
 		/**
 		 * The frequency at which requests are sent to SQS when processing messages in a
 		 * batch.
 		 */
+		@Nullable
 		private Duration sendBatchFrequency;
 
 		/**
 		 * The visibility timeout to set for messages received in a batch. If unset, the
 		 * queue default is used.
 		 */
+		@Nullable
 		private Duration visibilityTimeout;
 
 		/**
 		 * The minimum wait duration for a receiveMessage request in a batch. To avoid
 		 * unnecessary CPU usage, do not set this value to 0.
 		 */
+		@Nullable
 		private Duration waitTimeSeconds;
 
 		/**
 		 * The list of system attribute names to request for receiveMessage calls.
 		 */
+		@Nullable
 		private List<MessageSystemAttributeName> systemAttributeNames;
 
 		/**
 		 * The list of attribute names to request for receiveMessage calls.
 		 */
+		@Nullable
 		private List<String> attributeNames;
 
+		@Nullable
+		public Boolean getEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(Boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		@Nullable
 		public Integer getMaxNumberOfMessages() {
 			return maxNumberOfMessages;
 		}
@@ -189,6 +220,7 @@ public class SqsProperties extends AwsClientProperties {
 			this.maxNumberOfMessages = maxNumberOfMessages;
 		}
 
+		@Nullable
 		public Duration getSendBatchFrequency() {
 			return sendBatchFrequency;
 		}
@@ -197,6 +229,7 @@ public class SqsProperties extends AwsClientProperties {
 			this.sendBatchFrequency = sendBatchFrequency;
 		}
 
+		@Nullable
 		public Duration getVisibilityTimeout() {
 			return visibilityTimeout;
 		}
@@ -205,6 +238,7 @@ public class SqsProperties extends AwsClientProperties {
 			this.visibilityTimeout = visibilityTimeout;
 		}
 
+		@Nullable
 		public Duration getWaitTimeSeconds() {
 			return waitTimeSeconds;
 		}
@@ -213,6 +247,7 @@ public class SqsProperties extends AwsClientProperties {
 			this.waitTimeSeconds = waitTimeSeconds;
 		}
 
+		@Nullable
 		public List<MessageSystemAttributeName> getSystemAttributeNames() {
 			return systemAttributeNames;
 		}
@@ -221,6 +256,7 @@ public class SqsProperties extends AwsClientProperties {
 			this.systemAttributeNames = systemAttributeNames;
 		}
 
+		@Nullable
 		public List<String> getAttributeNames() {
 			return attributeNames;
 		}

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -17,12 +17,11 @@ package io.awspring.cloud.autoconfigure.sqs;
 
 import io.awspring.cloud.autoconfigure.AwsClientProperties;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
+import java.time.Duration;
+import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.lang.Nullable;
 import software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName;
-
-import java.time.Duration;
-import java.util.List;
 
 /**
  * Properties related to AWS SQS.
@@ -92,9 +91,8 @@ public class SqsProperties extends AwsClientProperties {
 	public static class Listener {
 
 		/**
-		 * The maximum concurrent messages that can be processed simultaneously for each
-		 * queue. Note that if acknowledgement batching is being used, the actual maximum
-		 * number of messages inflight might be higher.
+		 * The maximum concurrent messages that can be processed simultaneously for each queue. Note that if
+		 * acknowledgement batching is being used, the actual maximum number of messages inflight might be higher.
 		 */
 		@Nullable
 		private Integer maxConcurrentMessages;
@@ -158,14 +156,15 @@ public class SqsProperties extends AwsClientProperties {
 	/**
 	 * Configuration properties for SQS automatic batching using AWS SDK's {@code SqsAsyncBatchManager}.
 	 * 
-	 * <p>Automatic batching improves performance and reduces costs by combining multiple SQS requests
-	 * into fewer AWS API calls. When enabled, Spring Cloud AWS will use a {@code BatchingSqsClientAdapter}
-	 * that wraps the standard {@code SqsAsyncClient} with batching capabilities.
+	 * <p>
+	 * Automatic batching improves performance and reduces costs by combining multiple SQS requests into fewer AWS API
+	 * calls. When enabled, Spring Cloud AWS will use a {@code BatchingSqsClientAdapter} that wraps the standard
+	 * {@code SqsAsyncClient} with batching capabilities.
 	 * 
-	 * <p><strong>Important:</strong> Batched operations are processed asynchronously, which may result
-	 * in false positives where method calls appear to succeed locally but fail during actual transmission
-	 * to AWS. Applications should handle the returned {@code CompletableFuture} objects to detect
-	 * actual transmission errors.
+	 * <p>
+	 * <strong>Important:</strong> Batched operations are processed asynchronously, which may result in false positives
+	 * where method calls appear to succeed locally but fail during actual transmission to AWS. Applications should
+	 * handle the returned {@code CompletableFuture} objects to detect actual transmission errors.
 	 * 
 	 * @since 3.2
 	 */
@@ -174,38 +173,37 @@ public class SqsProperties extends AwsClientProperties {
 		/**
 		 * Enables SQS automatic batching using AWS SDK's SqsAsyncBatchManager.
 		 * 
-		 * <p>When set to {@code true}, the {@code SqsAsyncClient} bean will be wrapped
-		 * with a {@code BatchingSqsClientAdapter} that automatically batches requests
-		 * to improve performance and reduce AWS API calls.
+		 * <p>
+		 * When set to {@code true}, the {@code SqsAsyncClient} bean will be wrapped with a
+		 * {@code BatchingSqsClientAdapter} that automatically batches requests to improve performance and reduce AWS
+		 * API calls.
 		 * 
-		 * <p>Default is {@code false}.
+		 * <p>
+		 * Default is {@code false}.
 		 */
 		private boolean enabled = false;
 
 		/**
-		 * The maximum number of messages that can be processed in a single batch. The
-		 * maximum is 10.
+		 * The maximum number of messages that can be processed in a single batch. The maximum is 10.
 		 */
 		@Nullable
 		private Integer maxNumberOfMessages;
 
 		/**
-		 * The frequency at which requests are sent to SQS when processing messages in a
-		 * batch.
+		 * The frequency at which requests are sent to SQS when processing messages in a batch.
 		 */
 		@Nullable
 		private Duration sendBatchFrequency;
 
 		/**
-		 * The visibility timeout to set for messages received in a batch. If unset, the
-		 * queue default is used.
+		 * The visibility timeout to set for messages received in a batch. If unset, the queue default is used.
 		 */
 		@Nullable
 		private Duration visibilityTimeout;
 
 		/**
-		 * The minimum wait duration for a receiveMessage request in a batch. To avoid
-		 * unnecessary CPU usage, do not set this value to 0.
+		 * The minimum wait duration for a receiveMessage request in a batch. To avoid unnecessary CPU usage, do not set
+		 * this value to 0.
 		 */
 		@Nullable
 		private Duration waitTimeSeconds;
@@ -226,9 +224,9 @@ public class SqsProperties extends AwsClientProperties {
 			return enabled;
 		}
 
-        public void setEnabled(boolean enabled) {
-            this.enabled = enabled;
-        }
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
 
 		@Nullable
 		public Integer getMaxNumberOfMessages() {

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -202,8 +202,7 @@ public class SqsProperties extends AwsClientProperties {
 		@Nullable
 		private List<String> attributeNames;
 
-		@Nullable
-		public Boolean getEnabled() {
+		public boolean isEnabled() {
 			return enabled;
 		}
 

--- a/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
+++ b/spring-cloud-aws-autoconfigure/src/main/java/io/awspring/cloud/autoconfigure/sqs/SqsProperties.java
@@ -220,6 +220,15 @@ public class SqsProperties extends AwsClientProperties {
 		@Nullable
 		private List<String> attributeNames;
 
+		/**
+		 * The size of the scheduled thread pool used for batching operations. This thread pool handles periodic batch
+		 * sending and other scheduled tasks.
+		 * 
+		 * <p>
+		 * Default is {@code 5}.
+		 */
+		private int scheduledExecutorPoolSize = 5;
+
 		public boolean isEnabled() {
 			return enabled;
 		}
@@ -280,6 +289,14 @@ public class SqsProperties extends AwsClientProperties {
 
 		public void setAttributeNames(List<String> attributeNames) {
 			this.attributeNames = attributeNames;
+		}
+
+		public int getScheduledExecutorPoolSize() {
+			return scheduledExecutorPoolSize;
+		}
+
+		public void setScheduledExecutorPoolSize(int scheduledExecutorPoolSize) {
+			this.scheduledExecutorPoolSize = scheduledExecutorPoolSize;
 		}
 
 	}

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -35,6 +35,7 @@ import io.awspring.cloud.sqs.listener.ContainerOptionsBuilder;
 import io.awspring.cloud.sqs.listener.QueueNotFoundStrategy;
 import io.awspring.cloud.sqs.listener.errorhandler.AsyncErrorHandler;
 import io.awspring.cloud.sqs.listener.interceptor.AsyncMessageInterceptor;
+import io.awspring.cloud.sqs.operations.BatchingSqsClientAdapter;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import io.awspring.cloud.sqs.support.converter.MessagingMessageConverter;
 import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
@@ -328,6 +329,137 @@ class SqsAutoConfigurationTest {
 							.isEqualTo(converter);
 				});
 	}
+
+    @Test
+    void sqsBatchAutoConfigurationIsDisabledByDefault() {
+        this.contextRunner.run(context -> {
+            assertThat(context).hasSingleBean(SqsAsyncClient.class);
+            SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
+            assertThat(client).isNotInstanceOf(BatchingSqsClientAdapter.class);
+        });
+    }
+
+    @Test
+    void sqsBatchAutoConfigurationIsEnabled() {
+        this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:true").run(context -> {
+            assertThat(context.getBeansOfType(SqsAsyncClient.class)).hasSize(2);
+
+            SqsAsyncClient primary = context.getBean(SqsAsyncClient.class);
+            assertThat(primary).isInstanceOf(BatchingSqsClientAdapter.class);
+
+            assertThat(context).hasBean("sqsAsyncClient");
+            assertThat(context).hasBean("batchSqsAsyncClient");
+        });
+    }
+
+    @Test
+    void sqsBatchConfigurationProperties() {
+        this.contextRunner.withPropertyValues(
+                        "spring.cloud.aws.sqs.batch.enabled:true",
+                        "spring.cloud.aws.sqs.batch.max-number-of-messages:5",
+                        "spring.cloud.aws.sqs.batch.send-batch-frequency:PT0.5S")
+                .run(context -> {
+                    SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
+                    assertThat(client).isInstanceOf(BatchingSqsClientAdapter.class);
+                });
+    }
+
+    @Test
+    void sqsBatchConfigurationPropertiesWithAllSettings() {
+        this.contextRunner.withPropertyValues(
+                        "spring.cloud.aws.sqs.batch.enabled:true",
+                        "spring.cloud.aws.sqs.batch.max-number-of-messages:8",
+                        "spring.cloud.aws.sqs.batch.send-batch-frequency:PT1S",
+                        "spring.cloud.aws.sqs.batch.visibility-timeout:PT30S",
+                        "spring.cloud.aws.sqs.batch.wait-time-seconds:PT5S",
+                        "spring.cloud.aws.sqs.batch.system-attribute-names:SentTimestamp,ApproximateReceiveCount",
+                        "spring.cloud.aws.sqs.batch.attribute-names:attr1,attr2")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SqsProperties.class);
+                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
+                    
+                    assertThat(batchConfig.isEnabled()).isTrue();
+                    assertThat(batchConfig.getMaxNumberOfMessages()).isEqualTo(8);
+                    assertThat(batchConfig.getSendBatchFrequency()).isEqualTo(Duration.ofSeconds(1));
+                    assertThat(batchConfig.getVisibilityTimeout()).isEqualTo(Duration.ofSeconds(30));
+                    assertThat(batchConfig.getWaitTimeSeconds()).isEqualTo(Duration.ofSeconds(5));
+                    assertThat(batchConfig.getSystemAttributeNames()).containsExactly(
+                            software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName.SENT_TIMESTAMP,
+                            software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT);
+                    assertThat(batchConfig.getAttributeNames()).containsExactly("attr1", "attr2");
+
+                    SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
+                    assertThat(client).isInstanceOf(BatchingSqsClientAdapter.class);
+                });
+    }
+
+    @Test
+    void sqsBatchConfigurationPropertiesWithDefaults() {
+        this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:false")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SqsProperties.class);
+                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
+                    
+                    assertThat(batchConfig.isEnabled()).isFalse();
+                    assertThat(batchConfig.getMaxNumberOfMessages()).isNull();
+                    assertThat(batchConfig.getSendBatchFrequency()).isNull();
+                    assertThat(batchConfig.getVisibilityTimeout()).isNull();
+                    assertThat(batchConfig.getWaitTimeSeconds()).isNull();
+                    assertThat(batchConfig.getSystemAttributeNames()).isNull();
+                    assertThat(batchConfig.getAttributeNames()).isNull();
+                    
+                    assertThat(context).hasSingleBean(SqsAsyncClient.class);
+                    SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
+                    assertThat(client).isNotInstanceOf(BatchingSqsClientAdapter.class);
+                });
+    }
+
+    @Test
+    void sqsBatchConfigurationWithVisibilityTimeout() {
+        this.contextRunner.withPropertyValues(
+                        "spring.cloud.aws.sqs.batch.enabled:true",
+                        "spring.cloud.aws.sqs.batch.visibility-timeout:PT60S")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SqsProperties.class);
+                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
+                    
+                    assertThat(batchConfig.isEnabled()).isTrue();
+                    assertThat(batchConfig.getVisibilityTimeout()).isEqualTo(Duration.ofSeconds(60));
+                });
+    }
+
+    @Test
+    void sqsBatchConfigurationWithWaitTimeSeconds() {
+        this.contextRunner.withPropertyValues(
+                        "spring.cloud.aws.sqs.batch.enabled:true",
+                        "spring.cloud.aws.sqs.batch.wait-time-seconds:PT20S")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SqsProperties.class);
+                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
+                    
+                    assertThat(batchConfig.isEnabled()).isTrue();
+                    assertThat(batchConfig.getWaitTimeSeconds()).isEqualTo(Duration.ofSeconds(20));
+                });
+    }
+
+    @Test
+    void sqsBatchConfigurationWithAttributeNames() {
+        this.contextRunner.withPropertyValues(
+                        "spring.cloud.aws.sqs.batch.enabled:true",
+                        "spring.cloud.aws.sqs.batch.attribute-names:MessageGroupId,MessageDeduplicationId")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(SqsProperties.class);
+                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
+                    
+                    assertThat(batchConfig.isEnabled()).isTrue();
+                    assertThat(batchConfig.getAttributeNames()).containsExactly("MessageGroupId", "MessageDeduplicationId");
+                });
+    }
 
 	@Configuration(proxyBeanMethods = false)
 	static class CustomComponentsConfiguration {

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -70,6 +70,7 @@ import software.amazon.awssdk.services.sqs.model.Message;
  *
  * @author Tomaz Fernandes
  * @author Wei Jiang
+ * @author khc41
  */
 class SqsAutoConfigurationTest {
 

--- a/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
+++ b/spring-cloud-aws-autoconfigure/src/test/java/io/awspring/cloud/autoconfigure/sqs/SqsAutoConfigurationTest.java
@@ -331,136 +331,128 @@ class SqsAutoConfigurationTest {
 				});
 	}
 
-    @Test
-    void sqsBatchAutoConfigurationIsDisabledByDefault() {
-        this.contextRunner.run(context -> {
-            assertThat(context).hasSingleBean(SqsAsyncClient.class);
-            SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
-            assertThat(client).isNotInstanceOf(BatchingSqsClientAdapter.class);
-        });
-    }
+	@Test
+	void sqsBatchAutoConfigurationIsDisabledByDefault() {
+		this.contextRunner.run(context -> {
+			assertThat(context).hasSingleBean(SqsAsyncClient.class);
+			SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
+			assertThat(client).isNotInstanceOf(BatchingSqsClientAdapter.class);
+		});
+	}
 
-    @Test
-    void sqsBatchAutoConfigurationIsEnabled() {
-        this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:true").run(context -> {
-            assertThat(context.getBeansOfType(SqsAsyncClient.class)).hasSize(2);
+	@Test
+	void sqsBatchAutoConfigurationIsEnabled() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:true").run(context -> {
+			assertThat(context.getBeansOfType(SqsAsyncClient.class)).hasSize(2);
 
-            SqsAsyncClient primary = context.getBean(SqsAsyncClient.class);
-            assertThat(primary).isInstanceOf(BatchingSqsClientAdapter.class);
+			SqsAsyncClient primary = context.getBean(SqsAsyncClient.class);
+			assertThat(primary).isInstanceOf(BatchingSqsClientAdapter.class);
 
-            assertThat(context).hasBean("sqsAsyncClient");
-            assertThat(context).hasBean("batchSqsAsyncClient");
-        });
-    }
+			assertThat(context).hasBean("sqsAsyncClient");
+			assertThat(context).hasBean("batchSqsAsyncClient");
+		});
+	}
 
-    @Test
-    void sqsBatchConfigurationProperties() {
-        this.contextRunner.withPropertyValues(
-                        "spring.cloud.aws.sqs.batch.enabled:true",
-                        "spring.cloud.aws.sqs.batch.max-number-of-messages:5",
-                        "spring.cloud.aws.sqs.batch.send-batch-frequency:PT0.5S")
-                .run(context -> {
-                    SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
-                    assertThat(client).isInstanceOf(BatchingSqsClientAdapter.class);
-                });
-    }
+	@Test
+	void sqsBatchConfigurationProperties() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:true",
+				"spring.cloud.aws.sqs.batch.max-number-of-messages:5",
+				"spring.cloud.aws.sqs.batch.send-batch-frequency:PT0.5S").run(context -> {
+					SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
+					assertThat(client).isInstanceOf(BatchingSqsClientAdapter.class);
+				});
+	}
 
-    @Test
-    void sqsBatchConfigurationPropertiesWithAllSettings() {
-        this.contextRunner.withPropertyValues(
-                        "spring.cloud.aws.sqs.batch.enabled:true",
-                        "spring.cloud.aws.sqs.batch.max-number-of-messages:8",
-                        "spring.cloud.aws.sqs.batch.send-batch-frequency:PT1S",
-                        "spring.cloud.aws.sqs.batch.visibility-timeout:PT30S",
-                        "spring.cloud.aws.sqs.batch.wait-time-seconds:PT5S",
-                        "spring.cloud.aws.sqs.batch.system-attribute-names:SentTimestamp,ApproximateReceiveCount",
-                        "spring.cloud.aws.sqs.batch.attribute-names:attr1,attr2")
-                .run(context -> {
-                    assertThat(context).hasSingleBean(SqsProperties.class);
-                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
-                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
-                    
-                    assertThat(batchConfig.isEnabled()).isTrue();
-                    assertThat(batchConfig.getMaxNumberOfMessages()).isEqualTo(8);
-                    assertThat(batchConfig.getSendBatchFrequency()).isEqualTo(Duration.ofSeconds(1));
-                    assertThat(batchConfig.getVisibilityTimeout()).isEqualTo(Duration.ofSeconds(30));
-                    assertThat(batchConfig.getWaitTimeSeconds()).isEqualTo(Duration.ofSeconds(5));
-                    assertThat(batchConfig.getSystemAttributeNames()).containsExactly(
-                            software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName.SENT_TIMESTAMP,
-                            software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT);
-                    assertThat(batchConfig.getAttributeNames()).containsExactly("attr1", "attr2");
+	@Test
+	void sqsBatchConfigurationPropertiesWithAllSettings() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:true",
+				"spring.cloud.aws.sqs.batch.max-number-of-messages:8",
+				"spring.cloud.aws.sqs.batch.send-batch-frequency:PT1S",
+				"spring.cloud.aws.sqs.batch.visibility-timeout:PT30S",
+				"spring.cloud.aws.sqs.batch.wait-time-seconds:PT5S",
+				"spring.cloud.aws.sqs.batch.system-attribute-names:SentTimestamp,ApproximateReceiveCount",
+				"spring.cloud.aws.sqs.batch.attribute-names:attr1,attr2").run(context -> {
+					assertThat(context).hasSingleBean(SqsProperties.class);
+					SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+					SqsProperties.Batch batchConfig = sqsProperties.getBatch();
 
-                    SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
-                    assertThat(client).isInstanceOf(BatchingSqsClientAdapter.class);
-                });
-    }
+					assertThat(batchConfig.isEnabled()).isTrue();
+					assertThat(batchConfig.getMaxNumberOfMessages()).isEqualTo(8);
+					assertThat(batchConfig.getSendBatchFrequency()).isEqualTo(Duration.ofSeconds(1));
+					assertThat(batchConfig.getVisibilityTimeout()).isEqualTo(Duration.ofSeconds(30));
+					assertThat(batchConfig.getWaitTimeSeconds()).isEqualTo(Duration.ofSeconds(5));
+					assertThat(batchConfig.getSystemAttributeNames()).containsExactly(
+							software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName.SENT_TIMESTAMP,
+							software.amazon.awssdk.services.sqs.model.MessageSystemAttributeName.APPROXIMATE_RECEIVE_COUNT);
+					assertThat(batchConfig.getAttributeNames()).containsExactly("attr1", "attr2");
 
-    @Test
-    void sqsBatchConfigurationPropertiesWithDefaults() {
-        this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:false")
-                .run(context -> {
-                    assertThat(context).hasSingleBean(SqsProperties.class);
-                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
-                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
-                    
-                    assertThat(batchConfig.isEnabled()).isFalse();
-                    assertThat(batchConfig.getMaxNumberOfMessages()).isNull();
-                    assertThat(batchConfig.getSendBatchFrequency()).isNull();
-                    assertThat(batchConfig.getVisibilityTimeout()).isNull();
-                    assertThat(batchConfig.getWaitTimeSeconds()).isNull();
-                    assertThat(batchConfig.getSystemAttributeNames()).isNull();
-                    assertThat(batchConfig.getAttributeNames()).isNull();
-                    
-                    assertThat(context).hasSingleBean(SqsAsyncClient.class);
-                    SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
-                    assertThat(client).isNotInstanceOf(BatchingSqsClientAdapter.class);
-                });
-    }
+					SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
+					assertThat(client).isInstanceOf(BatchingSqsClientAdapter.class);
+				});
+	}
 
-    @Test
-    void sqsBatchConfigurationWithVisibilityTimeout() {
-        this.contextRunner.withPropertyValues(
-                        "spring.cloud.aws.sqs.batch.enabled:true",
-                        "spring.cloud.aws.sqs.batch.visibility-timeout:PT60S")
-                .run(context -> {
-                    assertThat(context).hasSingleBean(SqsProperties.class);
-                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
-                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
-                    
-                    assertThat(batchConfig.isEnabled()).isTrue();
-                    assertThat(batchConfig.getVisibilityTimeout()).isEqualTo(Duration.ofSeconds(60));
-                });
-    }
+	@Test
+	void sqsBatchConfigurationPropertiesWithDefaults() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:false").run(context -> {
+			assertThat(context).hasSingleBean(SqsProperties.class);
+			SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+			SqsProperties.Batch batchConfig = sqsProperties.getBatch();
 
-    @Test
-    void sqsBatchConfigurationWithWaitTimeSeconds() {
-        this.contextRunner.withPropertyValues(
-                        "spring.cloud.aws.sqs.batch.enabled:true",
-                        "spring.cloud.aws.sqs.batch.wait-time-seconds:PT20S")
-                .run(context -> {
-                    assertThat(context).hasSingleBean(SqsProperties.class);
-                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
-                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
-                    
-                    assertThat(batchConfig.isEnabled()).isTrue();
-                    assertThat(batchConfig.getWaitTimeSeconds()).isEqualTo(Duration.ofSeconds(20));
-                });
-    }
+			assertThat(batchConfig.isEnabled()).isFalse();
+			assertThat(batchConfig.getMaxNumberOfMessages()).isNull();
+			assertThat(batchConfig.getSendBatchFrequency()).isNull();
+			assertThat(batchConfig.getVisibilityTimeout()).isNull();
+			assertThat(batchConfig.getWaitTimeSeconds()).isNull();
+			assertThat(batchConfig.getSystemAttributeNames()).isNull();
+			assertThat(batchConfig.getAttributeNames()).isNull();
 
-    @Test
-    void sqsBatchConfigurationWithAttributeNames() {
-        this.contextRunner.withPropertyValues(
-                        "spring.cloud.aws.sqs.batch.enabled:true",
-                        "spring.cloud.aws.sqs.batch.attribute-names:MessageGroupId,MessageDeduplicationId")
-                .run(context -> {
-                    assertThat(context).hasSingleBean(SqsProperties.class);
-                    SqsProperties sqsProperties = context.getBean(SqsProperties.class);
-                    SqsProperties.Batch batchConfig = sqsProperties.getBatch();
-                    
-                    assertThat(batchConfig.isEnabled()).isTrue();
-                    assertThat(batchConfig.getAttributeNames()).containsExactly("MessageGroupId", "MessageDeduplicationId");
-                });
-    }
+			assertThat(context).hasSingleBean(SqsAsyncClient.class);
+			SqsAsyncClient client = context.getBean(SqsAsyncClient.class);
+			assertThat(client).isNotInstanceOf(BatchingSqsClientAdapter.class);
+		});
+	}
+
+	@Test
+	void sqsBatchConfigurationWithVisibilityTimeout() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:true",
+				"spring.cloud.aws.sqs.batch.visibility-timeout:PT60S").run(context -> {
+					assertThat(context).hasSingleBean(SqsProperties.class);
+					SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+					SqsProperties.Batch batchConfig = sqsProperties.getBatch();
+
+					assertThat(batchConfig.isEnabled()).isTrue();
+					assertThat(batchConfig.getVisibilityTimeout()).isEqualTo(Duration.ofSeconds(60));
+				});
+	}
+
+	@Test
+	void sqsBatchConfigurationWithWaitTimeSeconds() {
+		this.contextRunner.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:true",
+				"spring.cloud.aws.sqs.batch.wait-time-seconds:PT20S").run(context -> {
+					assertThat(context).hasSingleBean(SqsProperties.class);
+					SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+					SqsProperties.Batch batchConfig = sqsProperties.getBatch();
+
+					assertThat(batchConfig.isEnabled()).isTrue();
+					assertThat(batchConfig.getWaitTimeSeconds()).isEqualTo(Duration.ofSeconds(20));
+				});
+	}
+
+	@Test
+	void sqsBatchConfigurationWithAttributeNames() {
+		this.contextRunner
+				.withPropertyValues("spring.cloud.aws.sqs.batch.enabled:true",
+						"spring.cloud.aws.sqs.batch.attribute-names:MessageGroupId,MessageDeduplicationId")
+				.run(context -> {
+					assertThat(context).hasSingleBean(SqsProperties.class);
+					SqsProperties sqsProperties = context.getBean(SqsProperties.class);
+					SqsProperties.Batch batchConfig = sqsProperties.getBatch();
+
+					assertThat(batchConfig.isEnabled()).isTrue();
+					assertThat(batchConfig.getAttributeNames()).containsExactly("MessageGroupId",
+							"MessageDeduplicationId");
+				});
+	}
 
 	@Configuration(proxyBeanMethods = false)
 	static class CustomComponentsConfiguration {

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapter.java
@@ -1,5 +1,21 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.awspring.cloud.sqs.operations;
 
+import org.springframework.util.Assert;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
 import software.amazon.awssdk.services.sqs.model.*;
@@ -7,9 +23,60 @@ import software.amazon.awssdk.services.sqs.model.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+/**
+ * An {@link SqsAsyncClient} adapter that provides automatic batching capabilities using AWS SDK's
+ * {@link SqsAsyncBatchManager}.
+ * 
+ * <p>This adapter automatically batches SQS operations to improve performance and reduce costs by
+ * combining multiple requests into fewer AWS API calls. All standard SQS operations are supported:
+ * send message, receive message, delete message, and change message visibility.
+ * 
+ * <p><strong>Important - False Positives Warning:</strong> This adapter processes requests 
+ * asynchronously through batching. Method calls may return successfully before the actual request 
+ * is sent to AWS SQS. This can result in false positives where the operation appears to succeed 
+ * locally but fails during the actual transmission to AWS. Applications should:
+ * <ul>
+ * <li>Always handle the returned {@link CompletableFuture} to detect actual transmission errors</li>
+ * <li>Implement appropriate error handling and monitoring</li>
+ * <li>Consider retry mechanisms for critical operations</li>
+ * </ul>
+ * 
+ * <p><strong>Batch Optimization:</strong> The AWS SDK bypasses batching when {@code receiveMessage} is 
+ * called with any of the following parameters: {@code messageAttributeNames}, {@code messageSystemAttributeNames}, 
+ * {@code messageSystemAttributeNamesWithStrings}, or {@code overrideConfiguration}. To maintain consistent 
+ * batching performance, Spring Cloud AWS handles these parameters as follows:
+ * <ul>
+ * <li>{@code messageAttributeNames} - excluded from per-request, configured globally via {@code spring.cloud.aws.sqs.batch.attribute-names}</li>
+ * <li>{@code messageSystemAttributeNames} - excluded from per-request, configured globally via {@code spring.cloud.aws.sqs.batch.system-attribute-names}</li>
+ * <li>{@code messageSystemAttributeNamesWithStrings} - not used in Spring Cloud AWS {@code ReceiveMessageRequest}</li>
+ * <li>{@code overrideConfiguration} - not used in Spring Cloud AWS {@code ReceiveMessageRequest}</li>
+ * </ul>
+ * <p>This design prevents batch bypass and ensures optimal performance. 
+ * If per-request attribute configuration is required, consider disabling automatic batching.
+ * 
+ * <p>This adapter is automatically configured by Spring Cloud AWS when automatic batching is enabled.
+ * Users do not need to create instances directly - instead, enable batching through configuration:
+ * 
+ * <pre>
+ * spring.cloud.aws.sqs.batch.enabled=true
+ * </pre>
+ * 
+ * <p>Once enabled, all {@code SqsTemplate} operations will automatically use batching transparently.
+ * 
+ * @author khc41
+ * @since 3.2
+ * @see SqsAsyncBatchManager
+ * @see SqsAsyncClient
+ */
 public class BatchingSqsClientAdapter implements SqsAsyncClient {
 	private final SqsAsyncBatchManager batchManager;
 
+	/**
+	 * Creates a new {@code BatchingSqsClientAdapter} with the specified batch manager.
+	 * 
+	 * @param batchManager the {@link SqsAsyncBatchManager} to use for batching operations
+	 * @throws IllegalArgumentException if batchManager is null
+	 */
 	public BatchingSqsClientAdapter(SqsAsyncBatchManager batchManager) {
 		Assert.notNull(batchManager, "batchManager cannot be null");
 		this.batchManager = batchManager;
@@ -20,46 +87,126 @@ public class BatchingSqsClientAdapter implements SqsAsyncClient {
 		return SqsAsyncClient.SERVICE_NAME;
 	}
 
+	/**
+	 * Closes the underlying batch manager and releases associated resources.
+	 * 
+	 * <p>This method should be called when the adapter is no longer needed to ensure
+	 * proper cleanup of threads and connections.
+	 */
 	@Override
 	public void close() {
 		batchManager.close();
 	}
 
+	/**
+	 * Sends a message to the specified SQS queue using automatic batching.
+	 * 
+	 * <p><strong>Important:</strong> This method returns immediately, but the actual sending
+	 * is performed asynchronously. Handle the returned {@link CompletableFuture} to detect
+	 * transmission errors.
+	 * 
+	 * @param sendMessageRequest the request containing queue URL and message details
+	 * @return a {@link CompletableFuture} that completes with the send result
+	 */
 	@Override
 	public CompletableFuture<SendMessageResponse> sendMessage(SendMessageRequest sendMessageRequest) {
 		return batchManager.sendMessage(sendMessageRequest);
 	}
 
+	/**
+	 * Sends a message to the specified SQS queue using automatic batching.
+	 * 
+	 * <p><strong>Important:</strong> This method returns immediately, but the actual sending
+	 * is performed asynchronously. Handle the returned {@link CompletableFuture} to detect
+	 * transmission errors.
+	 * 
+	 * @param sendMessageRequest a consumer to configure the send message request
+	 * @return a {@link CompletableFuture} that completes with the send result
+	 */
 	@Override
 	public CompletableFuture<SendMessageResponse> sendMessage(Consumer<SendMessageRequest.Builder> sendMessageRequest) {
 		return batchManager.sendMessage(sendMessageRequest);
 	}
 
+	/**
+	 * Receives messages from the specified SQS queue using automatic batching.
+	 * 
+	 * <p>The batching manager may combine multiple receive requests to optimize
+	 * AWS API usage.
+	 * 
+	 * @param receiveMessageRequest the request containing queue URL and receive options
+	 * @return a {@link CompletableFuture} that completes with the received messages
+	 */
 	@Override
 	public CompletableFuture<ReceiveMessageResponse> receiveMessage(ReceiveMessageRequest receiveMessageRequest) {
 		return batchManager.receiveMessage(receiveMessageRequest);
 	}
 
+	/**
+	 * Receives messages from the specified SQS queue using automatic batching.
+	 * 
+	 * <p>The batching manager may combine multiple receive requests to optimize
+	 * AWS API usage.
+	 * 
+	 * @param receiveMessageRequest a consumer to configure the receive message request
+	 * @return a {@link CompletableFuture} that completes with the received messages
+	 */
 	@Override
 	public CompletableFuture<ReceiveMessageResponse> receiveMessage(Consumer<ReceiveMessageRequest.Builder> receiveMessageRequest) {
 		return batchManager.receiveMessage(receiveMessageRequest);
 	}
 
+	/**
+	 * Deletes a message from the specified SQS queue using automatic batching.
+	 * 
+	 * <p><strong>Important:</strong> The actual deletion may be delayed due to batching.
+	 * Handle the returned {@link CompletableFuture} to confirm successful deletion.
+	 * 
+	 * @param deleteMessageRequest the request containing queue URL and receipt handle
+	 * @return a {@link CompletableFuture} that completes with the deletion result
+	 */
 	@Override
 	public CompletableFuture<DeleteMessageResponse> deleteMessage(DeleteMessageRequest deleteMessageRequest) {
 		return batchManager.deleteMessage(deleteMessageRequest);
 	}
 
+	/**
+	 * Deletes a message from the specified SQS queue using automatic batching.
+	 * 
+	 * <p><strong>Important:</strong> The actual deletion may be delayed due to batching.
+	 * Handle the returned {@link CompletableFuture} to confirm successful deletion.
+	 * 
+	 * @param deleteMessageRequest a consumer to configure the delete message request
+	 * @return a {@link CompletableFuture} that completes with the deletion result
+	 */
 	@Override
 	public CompletableFuture<DeleteMessageResponse> deleteMessage(Consumer<DeleteMessageRequest.Builder> deleteMessageRequest) {
 		return batchManager.deleteMessage(deleteMessageRequest);
 	}
 
+	/**
+	 * Changes the visibility timeout of a message in the specified SQS queue using automatic batching.
+	 * 
+	 * <p>The batching manager may combine multiple visibility change requests to optimize
+	 * AWS API usage.
+	 * 
+	 * @param changeMessageVisibilityRequest the request containing queue URL, receipt handle, and new timeout
+	 * @return a {@link CompletableFuture} that completes with the visibility change result
+	 */
 	@Override
 	public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest) {
 		return batchManager.changeMessageVisibility(changeMessageVisibilityRequest);
 	}
 
+	/**
+	 * Changes the visibility timeout of a message in the specified SQS queue using automatic batching.
+	 * 
+	 * <p>The batching manager may combine multiple visibility change requests to optimize
+	 * AWS API usage.
+	 * 
+	 * @param changeMessageVisibilityRequest a consumer to configure the change visibility request
+	 * @return a {@link CompletableFuture} that completes with the visibility change result
+	 */
 	@Override
 	public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(Consumer<ChangeMessageVisibilityRequest.Builder> changeMessageVisibilityRequest) {
 		return batchManager.changeMessageVisibility(changeMessageVisibilityRequest);

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapter.java
@@ -1,0 +1,66 @@
+package io.awspring.cloud.sqs.operations;
+
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class BatchingSqsClientAdapter implements SqsAsyncClient {
+	private final SqsAsyncBatchManager batchManager;
+
+	public BatchingSqsClientAdapter(SqsAsyncBatchManager batchManager) {
+		this.batchManager = batchManager;
+	}
+
+	@Override
+	public String serviceName() {
+		return SqsAsyncClient.SERVICE_NAME;
+	}
+
+	@Override
+	public void close() {
+		batchManager.close();
+	}
+
+	@Override
+	public CompletableFuture<SendMessageResponse> sendMessage(SendMessageRequest sendMessageRequest) {
+		return batchManager.sendMessage(sendMessageRequest);
+	}
+
+	@Override
+	public CompletableFuture<SendMessageResponse> sendMessage(Consumer<SendMessageRequest.Builder> sendMessageRequest) {
+		return batchManager.sendMessage(sendMessageRequest);
+	}
+
+	@Override
+	public CompletableFuture<ReceiveMessageResponse> receiveMessage(ReceiveMessageRequest receiveMessageRequest) {
+		return batchManager.receiveMessage(receiveMessageRequest);
+	}
+
+	@Override
+	public CompletableFuture<ReceiveMessageResponse> receiveMessage(Consumer<ReceiveMessageRequest.Builder> receiveMessageRequest) {
+		return batchManager.receiveMessage(receiveMessageRequest);
+	}
+
+	@Override
+	public CompletableFuture<DeleteMessageResponse> deleteMessage(DeleteMessageRequest deleteMessageRequest) {
+		return batchManager.deleteMessage(deleteMessageRequest);
+	}
+
+	@Override
+	public CompletableFuture<DeleteMessageResponse> deleteMessage(Consumer<DeleteMessageRequest.Builder> deleteMessageRequest) {
+		return batchManager.deleteMessage(deleteMessageRequest);
+	}
+
+	@Override
+	public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest) {
+		return batchManager.changeMessageVisibility(changeMessageVisibilityRequest);
+	}
+
+	@Override
+	public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(Consumer<ChangeMessageVisibilityRequest.Builder> changeMessageVisibilityRequest) {
+		return batchManager.changeMessageVisibility(changeMessageVisibilityRequest);
+	}
+}

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapter.java
@@ -15,53 +15,60 @@
  */
 package io.awspring.cloud.sqs.operations;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.springframework.util.Assert;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
 import software.amazon.awssdk.services.sqs.model.*;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-
 /**
  * An {@link SqsAsyncClient} adapter that provides automatic batching capabilities using AWS SDK's
  * {@link SqsAsyncBatchManager}.
  * 
- * <p>This adapter automatically batches SQS operations to improve performance and reduce costs by
- * combining multiple requests into fewer AWS API calls. All standard SQS operations are supported:
- * send message, receive message, delete message, and change message visibility.
+ * <p>
+ * This adapter automatically batches SQS operations to improve performance and reduce costs by combining multiple
+ * requests into fewer AWS API calls. All standard SQS operations are supported: send message, receive message, delete
+ * message, and change message visibility.
  * 
- * <p><strong>Important - False Positives Warning:</strong> This adapter processes requests 
- * asynchronously through batching. Method calls may return successfully before the actual request 
- * is sent to AWS SQS. This can result in false positives where the operation appears to succeed 
- * locally but fails during the actual transmission to AWS. Applications should:
+ * <p>
+ * <strong>Important - False Positives Warning:</strong> This adapter processes requests asynchronously through
+ * batching. Method calls may return successfully before the actual request is sent to AWS SQS. This can result in false
+ * positives where the operation appears to succeed locally but fails during the actual transmission to AWS.
+ * Applications should:
  * <ul>
  * <li>Always handle the returned {@link CompletableFuture} to detect actual transmission errors</li>
  * <li>Implement appropriate error handling and monitoring</li>
  * <li>Consider retry mechanisms for critical operations</li>
  * </ul>
  * 
- * <p><strong>Batch Optimization:</strong> The AWS SDK bypasses batching when {@code receiveMessage} is 
- * called with any of the following parameters: {@code messageAttributeNames}, {@code messageSystemAttributeNames}, 
- * {@code messageSystemAttributeNamesWithStrings}, or {@code overrideConfiguration}. To maintain consistent 
- * batching performance, Spring Cloud AWS handles these parameters as follows:
+ * <p>
+ * <strong>Batch Optimization:</strong> The AWS SDK bypasses batching when {@code receiveMessage} is called with any of
+ * the following parameters: {@code messageAttributeNames}, {@code messageSystemAttributeNames},
+ * {@code messageSystemAttributeNamesWithStrings}, or {@code overrideConfiguration}. To maintain consistent batching
+ * performance, Spring Cloud AWS handles these parameters as follows:
  * <ul>
- * <li>{@code messageAttributeNames} - excluded from per-request, configured globally via {@code spring.cloud.aws.sqs.batch.attribute-names}</li>
- * <li>{@code messageSystemAttributeNames} - excluded from per-request, configured globally via {@code spring.cloud.aws.sqs.batch.system-attribute-names}</li>
+ * <li>{@code messageAttributeNames} - excluded from per-request, configured globally via
+ * {@code spring.cloud.aws.sqs.batch.attribute-names}</li>
+ * <li>{@code messageSystemAttributeNames} - excluded from per-request, configured globally via
+ * {@code spring.cloud.aws.sqs.batch.system-attribute-names}</li>
  * <li>{@code messageSystemAttributeNamesWithStrings} - not used in Spring Cloud AWS {@code ReceiveMessageRequest}</li>
  * <li>{@code overrideConfiguration} - not used in Spring Cloud AWS {@code ReceiveMessageRequest}</li>
  * </ul>
- * <p>This design prevents batch bypass and ensures optimal performance. 
- * If per-request attribute configuration is required, consider disabling automatic batching.
+ * <p>
+ * This design prevents batch bypass and ensures optimal performance. If per-request attribute configuration is
+ * required, consider disabling automatic batching.
  * 
- * <p>This adapter is automatically configured by Spring Cloud AWS when automatic batching is enabled.
- * Users do not need to create instances directly - instead, enable batching through configuration:
+ * <p>
+ * This adapter is automatically configured by Spring Cloud AWS when automatic batching is enabled. Users do not need to
+ * create instances directly - instead, enable batching through configuration:
  * 
  * <pre>
- * spring.cloud.aws.sqs.batch.enabled=true
+ * spring.cloud.aws.sqs.batch.enabled = true
  * </pre>
  * 
- * <p>Once enabled, all {@code SqsTemplate} operations will automatically use batching transparently.
+ * <p>
+ * Once enabled, all {@code SqsTemplate} operations will automatically use batching transparently.
  * 
  * @author khc41
  * @since 3.2
@@ -90,8 +97,9 @@ public class BatchingSqsClientAdapter implements SqsAsyncClient {
 	/**
 	 * Closes the underlying batch manager and releases associated resources.
 	 * 
-	 * <p>This method should be called when the adapter is no longer needed to ensure
-	 * proper cleanup of threads and connections.
+	 * <p>
+	 * This method should be called when the adapter is no longer needed to ensure proper cleanup of threads and
+	 * connections.
 	 */
 	@Override
 	public void close() {
@@ -101,9 +109,9 @@ public class BatchingSqsClientAdapter implements SqsAsyncClient {
 	/**
 	 * Sends a message to the specified SQS queue using automatic batching.
 	 * 
-	 * <p><strong>Important:</strong> This method returns immediately, but the actual sending
-	 * is performed asynchronously. Handle the returned {@link CompletableFuture} to detect
-	 * transmission errors.
+	 * <p>
+	 * <strong>Important:</strong> This method returns immediately, but the actual sending is performed asynchronously.
+	 * Handle the returned {@link CompletableFuture} to detect transmission errors.
 	 * 
 	 * @param sendMessageRequest the request containing queue URL and message details
 	 * @return a {@link CompletableFuture} that completes with the send result
@@ -116,9 +124,9 @@ public class BatchingSqsClientAdapter implements SqsAsyncClient {
 	/**
 	 * Sends a message to the specified SQS queue using automatic batching.
 	 * 
-	 * <p><strong>Important:</strong> This method returns immediately, but the actual sending
-	 * is performed asynchronously. Handle the returned {@link CompletableFuture} to detect
-	 * transmission errors.
+	 * <p>
+	 * <strong>Important:</strong> This method returns immediately, but the actual sending is performed asynchronously.
+	 * Handle the returned {@link CompletableFuture} to detect transmission errors.
 	 * 
 	 * @param sendMessageRequest a consumer to configure the send message request
 	 * @return a {@link CompletableFuture} that completes with the send result
@@ -131,8 +139,8 @@ public class BatchingSqsClientAdapter implements SqsAsyncClient {
 	/**
 	 * Receives messages from the specified SQS queue using automatic batching.
 	 * 
-	 * <p>The batching manager may combine multiple receive requests to optimize
-	 * AWS API usage.
+	 * <p>
+	 * The batching manager may combine multiple receive requests to optimize AWS API usage.
 	 * 
 	 * @param receiveMessageRequest the request containing queue URL and receive options
 	 * @return a {@link CompletableFuture} that completes with the received messages
@@ -145,22 +153,24 @@ public class BatchingSqsClientAdapter implements SqsAsyncClient {
 	/**
 	 * Receives messages from the specified SQS queue using automatic batching.
 	 * 
-	 * <p>The batching manager may combine multiple receive requests to optimize
-	 * AWS API usage.
+	 * <p>
+	 * The batching manager may combine multiple receive requests to optimize AWS API usage.
 	 * 
 	 * @param receiveMessageRequest a consumer to configure the receive message request
 	 * @return a {@link CompletableFuture} that completes with the received messages
 	 */
 	@Override
-	public CompletableFuture<ReceiveMessageResponse> receiveMessage(Consumer<ReceiveMessageRequest.Builder> receiveMessageRequest) {
+	public CompletableFuture<ReceiveMessageResponse> receiveMessage(
+			Consumer<ReceiveMessageRequest.Builder> receiveMessageRequest) {
 		return batchManager.receiveMessage(receiveMessageRequest);
 	}
 
 	/**
 	 * Deletes a message from the specified SQS queue using automatic batching.
 	 * 
-	 * <p><strong>Important:</strong> The actual deletion may be delayed due to batching.
-	 * Handle the returned {@link CompletableFuture} to confirm successful deletion.
+	 * <p>
+	 * <strong>Important:</strong> The actual deletion may be delayed due to batching. Handle the returned
+	 * {@link CompletableFuture} to confirm successful deletion.
 	 * 
 	 * @param deleteMessageRequest the request containing queue URL and receipt handle
 	 * @return a {@link CompletableFuture} that completes with the deletion result
@@ -173,42 +183,46 @@ public class BatchingSqsClientAdapter implements SqsAsyncClient {
 	/**
 	 * Deletes a message from the specified SQS queue using automatic batching.
 	 * 
-	 * <p><strong>Important:</strong> The actual deletion may be delayed due to batching.
-	 * Handle the returned {@link CompletableFuture} to confirm successful deletion.
+	 * <p>
+	 * <strong>Important:</strong> The actual deletion may be delayed due to batching. Handle the returned
+	 * {@link CompletableFuture} to confirm successful deletion.
 	 * 
 	 * @param deleteMessageRequest a consumer to configure the delete message request
 	 * @return a {@link CompletableFuture} that completes with the deletion result
 	 */
 	@Override
-	public CompletableFuture<DeleteMessageResponse> deleteMessage(Consumer<DeleteMessageRequest.Builder> deleteMessageRequest) {
+	public CompletableFuture<DeleteMessageResponse> deleteMessage(
+			Consumer<DeleteMessageRequest.Builder> deleteMessageRequest) {
 		return batchManager.deleteMessage(deleteMessageRequest);
 	}
 
 	/**
 	 * Changes the visibility timeout of a message in the specified SQS queue using automatic batching.
 	 * 
-	 * <p>The batching manager may combine multiple visibility change requests to optimize
-	 * AWS API usage.
+	 * <p>
+	 * The batching manager may combine multiple visibility change requests to optimize AWS API usage.
 	 * 
 	 * @param changeMessageVisibilityRequest the request containing queue URL, receipt handle, and new timeout
 	 * @return a {@link CompletableFuture} that completes with the visibility change result
 	 */
 	@Override
-	public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest) {
+	public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(
+			ChangeMessageVisibilityRequest changeMessageVisibilityRequest) {
 		return batchManager.changeMessageVisibility(changeMessageVisibilityRequest);
 	}
 
 	/**
 	 * Changes the visibility timeout of a message in the specified SQS queue using automatic batching.
 	 * 
-	 * <p>The batching manager may combine multiple visibility change requests to optimize
-	 * AWS API usage.
+	 * <p>
+	 * The batching manager may combine multiple visibility change requests to optimize AWS API usage.
 	 * 
 	 * @param changeMessageVisibilityRequest a consumer to configure the change visibility request
 	 * @return a {@link CompletableFuture} that completes with the visibility change result
 	 */
 	@Override
-	public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(Consumer<ChangeMessageVisibilityRequest.Builder> changeMessageVisibilityRequest) {
+	public CompletableFuture<ChangeMessageVisibilityResponse> changeMessageVisibility(
+			Consumer<ChangeMessageVisibilityRequest.Builder> changeMessageVisibilityRequest) {
 		return batchManager.changeMessageVisibility(changeMessageVisibilityRequest);
 	}
 }

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapter.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapter.java
@@ -11,6 +11,7 @@ public class BatchingSqsClientAdapter implements SqsAsyncClient {
 	private final SqsAsyncBatchManager batchManager;
 
 	public BatchingSqsClientAdapter(SqsAsyncBatchManager batchManager) {
+		Assert.notNull(batchManager, "batchManager cannot be null");
 		this.batchManager = batchManager;
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -605,8 +605,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	private ReceiveMessageRequest doCreateReceiveMessageRequest(Duration pollTimeout, Integer maxNumberOfMessages,
 			QueueAttributes attributes, Map<String, Object> additionalHeaders) {
 		ReceiveMessageRequest.Builder builder = ReceiveMessageRequest.builder().queueUrl(attributes.getQueueUrl())
-				.maxNumberOfMessages(maxNumberOfMessages).messageAttributeNames(this.messageAttributeNames)
-				.attributeNamesWithStrings(this.messageSystemAttributeNames)
+				.maxNumberOfMessages(maxNumberOfMessages)
 				.waitTimeSeconds(toInt(pollTimeout.toSeconds()));
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER)) {
 			builder.visibilityTimeout(
@@ -618,6 +617,10 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 					getValueAs(additionalHeaders, SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER, UUID.class)
 							.toString());
 		}
+        if (!(this.sqsAsyncClient instanceof BatchingSqsClientAdapter)) {
+            builder.messageAttributeNames(this.messageAttributeNames)
+                .attributeNamesWithStrings(this.messageSystemAttributeNames);
+        }
 		return builder.build();
 	}
 

--- a/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
+++ b/spring-cloud-aws-sqs/src/main/java/io/awspring/cloud/sqs/operations/SqsTemplate.java
@@ -605,8 +605,7 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 	private ReceiveMessageRequest doCreateReceiveMessageRequest(Duration pollTimeout, Integer maxNumberOfMessages,
 			QueueAttributes attributes, Map<String, Object> additionalHeaders) {
 		ReceiveMessageRequest.Builder builder = ReceiveMessageRequest.builder().queueUrl(attributes.getQueueUrl())
-				.maxNumberOfMessages(maxNumberOfMessages)
-				.waitTimeSeconds(toInt(pollTimeout.toSeconds()));
+				.maxNumberOfMessages(maxNumberOfMessages).waitTimeSeconds(toInt(pollTimeout.toSeconds()));
 		if (additionalHeaders.containsKey(SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER)) {
 			builder.visibilityTimeout(
 					toInt(getValueAs(additionalHeaders, SqsHeaders.SQS_VISIBILITY_TIMEOUT_HEADER, Duration.class)
@@ -617,10 +616,10 @@ public class SqsTemplate extends AbstractMessagingTemplate<Message> implements S
 					getValueAs(additionalHeaders, SqsHeaders.SQS_RECEIVE_REQUEST_ATTEMPT_ID_HEADER, UUID.class)
 							.toString());
 		}
-        if (!(this.sqsAsyncClient instanceof BatchingSqsClientAdapter)) {
-            builder.messageAttributeNames(this.messageAttributeNames)
-                .attributeNamesWithStrings(this.messageSystemAttributeNames);
-        }
+		if (!(this.sqsAsyncClient instanceof BatchingSqsClientAdapter)) {
+			builder.messageAttributeNames(this.messageAttributeNames)
+					.attributeNamesWithStrings(this.messageSystemAttributeNames);
+		}
 		return builder.build();
 	}
 

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BatchingSqsClientAdapterIntegrationTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/integration/BatchingSqsClientAdapterIntegrationTests.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.integration;
+
+import io.awspring.cloud.sqs.operations.BatchingSqsClientAdapter;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the Sqs Batching Client Adapter.
+ *
+ * @author khc41
+ */
+@SpringBootTest
+public class BatchingSqsClientAdapterIntegrationTests extends BaseSqsIntegrationTest {
+
+    private static final String BASE_QUEUE_NAME = "batching-test-queue";
+
+    @Autowired
+    private SqsAsyncClient asyncClient;
+
+    @Test
+    void shouldReturnCorrectServiceName() {
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String serviceName = adapter.serviceName();
+            assertThat(serviceName).isEqualTo(SqsAsyncClient.SERVICE_NAME);
+        }
+    }
+
+    @Test
+    void shouldSendMessageThroughBatchManager() {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String messageBody = "Test message for batching";
+            SendMessageRequest request = SendMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .messageBody(messageBody)
+                    .build();
+
+            SendMessageResponse response = adapter.sendMessage(request).join();
+
+            assertThat(response.messageId()).isNotNull();
+
+            ReceiveMessageResponse received = this.asyncClient.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(1)
+                    .build()).join();
+
+            assertThat(received.messages()).hasSize(1);
+            assertThat(received.messages().get(0).body()).isEqualTo(messageBody);
+        }
+    }
+
+    @Test
+    void shouldSendMessageWithConsumer() {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String messageBody = "Test message with consumer";
+
+            SendMessageResponse response = adapter.sendMessage(builder ->
+                    builder.queueUrl(queueName).messageBody(messageBody)).join();
+
+            assertThat(response.messageId()).isNotNull();
+
+            ReceiveMessageResponse received = this.asyncClient.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(1)
+                    .build()).join();
+
+            assertThat(received.messages()).hasSize(1);
+            assertThat(received.messages().get(0).body()).isEqualTo(messageBody);
+        }
+    }
+
+    @Test
+    void shouldReceiveMessageThroughBatchManager() throws InterruptedException {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String messageBody = "Test message for receiving";
+            this.asyncClient.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .messageBody(messageBody)
+                    .build()).join();
+
+            Thread.sleep(200);
+
+            ReceiveMessageResponse response = adapter.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(1)
+                    .build()).join();
+
+            assertThat(response.messages()).hasSize(1);
+            assertThat(response.messages().get(0).body()).isEqualTo(messageBody);
+        }
+    }
+
+    @Test
+    void shouldReceiveMessageWithConsumer() throws InterruptedException {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String messageBody = "Test message for receiving with consumer";
+            this.asyncClient.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .messageBody(messageBody)
+                    .build()).join();
+
+            Thread.sleep(200);
+
+            ReceiveMessageResponse response = adapter.receiveMessage(builder ->
+                    builder.queueUrl(queueName).maxNumberOfMessages(1)).join();
+
+            assertThat(response.messages()).hasSize(1);
+            assertThat(response.messages().get(0).body()).isEqualTo(messageBody);
+        }
+    }
+
+    @Test
+    void shouldDeleteMessageThroughBatchManager() {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String messageBody = "Test message for deletion";
+            this.asyncClient.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .messageBody(messageBody)
+                    .build()).join();
+
+            ReceiveMessageResponse received = this.asyncClient.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(1)
+                    .build()).join();
+
+            assertThat(received.messages()).hasSize(1);
+            String receiptHandle = received.messages().get(0).receiptHandle();
+
+            DeleteMessageResponse deleteResponse = adapter.deleteMessage(DeleteMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .receiptHandle(receiptHandle)
+                    .build()).join();
+
+            assertThat(deleteResponse).isNotNull();
+
+            ReceiveMessageResponse afterDelete = this.asyncClient.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(1)
+                    .waitTimeSeconds(1)
+                    .build()).join();
+
+            assertThat(afterDelete.messages()).isEmpty();
+        }
+    }
+
+    @Test
+    void shouldDeleteMessageWithConsumer() {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String messageBody = "Test message for deletion with consumer";
+            this.asyncClient.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .messageBody(messageBody)
+                    .build()).join();
+
+            ReceiveMessageResponse received = this.asyncClient.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(1)
+                    .build()).join();
+
+            String receiptHandle = received.messages().get(0).receiptHandle();
+
+            DeleteMessageResponse deleteResponse = adapter.deleteMessage(builder ->
+                    builder.queueUrl(queueName).receiptHandle(receiptHandle)).join();
+
+            assertThat(deleteResponse).isNotNull();
+        }
+    }
+
+    @Test
+    void shouldChangeMessageVisibilityThroughBatchManager() {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String messageBody = "Test message for visibility change";
+            this.asyncClient.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .messageBody(messageBody)
+                    .build()).join();
+
+            ReceiveMessageResponse received = this.asyncClient.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(1)
+                    .visibilityTimeout(5)
+                    .build()).join();
+
+            String receiptHandle = received.messages().get(0).receiptHandle();
+
+            ChangeMessageVisibilityResponse response = adapter.changeMessageVisibility(
+                    ChangeMessageVisibilityRequest.builder()
+                            .queueUrl(queueName)
+                            .receiptHandle(receiptHandle)
+                            .visibilityTimeout(30)
+                            .build()).join();
+
+            assertThat(response).isNotNull();
+        }
+    }
+
+    @Test
+    void shouldChangeMessageVisibilityWithConsumer() {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            String messageBody = "Test message for visibility change with consumer";
+            this.asyncClient.sendMessage(SendMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .messageBody(messageBody)
+                    .build()).join();
+
+            ReceiveMessageResponse received = this.asyncClient.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(1)
+                    .visibilityTimeout(5)
+                    .build()).join();
+
+            String receiptHandle = received.messages().get(0).receiptHandle();
+
+            ChangeMessageVisibilityResponse response = adapter.changeMessageVisibility(builder ->
+                    builder.queueUrl(queueName).receiptHandle(receiptHandle).visibilityTimeout(30)).join();
+
+            assertThat(response).isNotNull();
+        }
+    }
+
+    @Test
+    void shouldHandleBatchingEfficiently() throws InterruptedException {
+        String queueName = createUniqueQueueName();
+        createQueue(this.asyncClient, queueName).join();
+
+        try (BatchingSqsClientAdapter adapter = createBatchingAdapter()) {
+            int messageCount = 5;
+            String messageBodyPrefix = "Batch test message ";
+
+            CompletableFuture<SendMessageResponse>[] futures = new CompletableFuture[messageCount];
+
+            for (int i = 0; i < messageCount; i++) {
+                futures[i] = adapter.sendMessage(SendMessageRequest.builder()
+                        .queueUrl(queueName)
+                        .messageBody(messageBodyPrefix + i)
+                        .build());
+            }
+
+            CompletableFuture.allOf(futures).join();
+
+            for (CompletableFuture<SendMessageResponse> future : futures) {
+                assertThat(future.join().messageId()).isNotNull();
+            }
+
+            Thread.sleep(200);
+
+            ReceiveMessageResponse received = this.asyncClient.receiveMessage(ReceiveMessageRequest.builder()
+                    .queueUrl(queueName)
+                    .maxNumberOfMessages(10)
+                    .build()).join();
+
+            assertThat(received.messages()).hasSize(messageCount);
+        }
+    }
+
+    private String createUniqueQueueName() {
+        return BASE_QUEUE_NAME + "-" + UUID.randomUUID().toString().substring(0, 8);
+    }
+
+    private BatchingSqsClientAdapter createBatchingAdapter() {
+        SqsAsyncBatchManager batchManager = SqsAsyncBatchManager.builder()
+                .client(this.asyncClient)
+                .scheduledExecutor(Executors.newScheduledThreadPool(2))
+                .overrideConfiguration(builder -> builder
+                        .maxBatchSize(10)
+                        .sendRequestFrequency(Duration.ofMillis(100)))
+                .build();
+
+        return new BatchingSqsClientAdapter(batchManager);
+    }
+
+    @Configuration
+    static class SQSConfiguration {
+
+        @Bean
+        SqsAsyncClient client() {
+            return createAsyncClient();
+        }
+    }
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapterTests.java
@@ -15,6 +15,16 @@
  */
 package io.awspring.cloud.sqs.operations;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,300 +34,251 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
 import software.amazon.awssdk.services.sqs.model.*;
 
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-
 /**
  * @author khc41
  */
 @ExtendWith(MockitoExtension.class)
 class BatchingSqsClientAdapterTests {
-    SqsAsyncBatchManager mockBatchManager;
+	SqsAsyncBatchManager mockBatchManager;
 
-    BatchingSqsClientAdapter mockAdapter;
+	BatchingSqsClientAdapter mockAdapter;
 
-    @BeforeEach
-    void beforeEach() {
-        mockBatchManager = mock(SqsAsyncBatchManager.class);
-        mockAdapter = new BatchingSqsClientAdapter(mockBatchManager);
-    }
+	@BeforeEach
+	void beforeEach() {
+		mockBatchManager = mock(SqsAsyncBatchManager.class);
+		mockAdapter = new BatchingSqsClientAdapter(mockBatchManager);
+	}
 
-    @Test
-    void shouldThrowExceptionWhenBatchManagerIsNull() {
-        assertThatThrownBy(() -> new BatchingSqsClientAdapter(null))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("batchManager cannot be null");
-    }
+	@Test
+	void shouldThrowExceptionWhenBatchManagerIsNull() {
+		assertThatThrownBy(() -> new BatchingSqsClientAdapter(null)).isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("batchManager cannot be null");
+	}
 
-    @Test
-    void shouldReturnCorrectServiceName() {
-        String serviceName = mockAdapter.serviceName();
-        assertThat(serviceName).isEqualTo(SqsAsyncClient.SERVICE_NAME);
-    }
+	@Test
+	void shouldReturnCorrectServiceName() {
+		String serviceName = mockAdapter.serviceName();
+		assertThat(serviceName).isEqualTo(SqsAsyncClient.SERVICE_NAME);
+	}
 
-    @Test
-    void shouldDelegateBatchManagerClose() {
-        mockAdapter.close();
-        then(mockBatchManager).should().close();
-    }
+	@Test
+	void shouldDelegateBatchManagerClose() {
+		mockAdapter.close();
+		then(mockBatchManager).should().close();
+	}
 
-    @Test
-    void shouldDelegateSendMessageWithRequest() {
-        String queueUrl = "test-queue";
-        String messageBody = "test-message";
+	@Test
+	void shouldDelegateSendMessageWithRequest() {
+		String queueUrl = "test-queue";
+		String messageBody = "test-message";
 
-        SendMessageRequest request = SendMessageRequest.builder()
-                .queueUrl(queueUrl)
-                .messageBody(messageBody)
-                .build();
-        SendMessageResponse expectedResponse = SendMessageResponse.builder()
-                .messageId(UUID.randomUUID().toString())
-                .build();
-        given(mockBatchManager.sendMessage(request))
-                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+		SendMessageRequest request = SendMessageRequest.builder().queueUrl(queueUrl).messageBody(messageBody).build();
+		SendMessageResponse expectedResponse = SendMessageResponse.builder().messageId(UUID.randomUUID().toString())
+				.build();
+		given(mockBatchManager.sendMessage(request)).willReturn(CompletableFuture.completedFuture(expectedResponse));
 
-        CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(request);
+		CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(request);
 
-        assertThat(result).isCompletedWithValue(expectedResponse);
-        then(mockBatchManager).should().sendMessage(request);
-    }
+		assertThat(result).isCompletedWithValue(expectedResponse);
+		then(mockBatchManager).should().sendMessage(request);
+	}
 
-    @Test
-    void shouldDelegateSendMessageWithConsumer() {
-        String queueUrl = "test-queue";
-        String messageBody = "test-message";
+	@Test
+	void shouldDelegateSendMessageWithConsumer() {
+		String queueUrl = "test-queue";
+		String messageBody = "test-message";
 
-        Consumer<SendMessageRequest.Builder> requestConsumer = builder ->
-                builder.queueUrl(queueUrl).messageBody(messageBody);
-        SendMessageResponse expectedResponse = SendMessageResponse.builder()
-                .messageId(UUID.randomUUID().toString())
-                .build();
-        given(mockBatchManager.sendMessage(any(Consumer.class)))
-                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+		Consumer<SendMessageRequest.Builder> requestConsumer = builder -> builder.queueUrl(queueUrl)
+				.messageBody(messageBody);
+		SendMessageResponse expectedResponse = SendMessageResponse.builder().messageId(UUID.randomUUID().toString())
+				.build();
+		given(mockBatchManager.sendMessage(any(Consumer.class)))
+				.willReturn(CompletableFuture.completedFuture(expectedResponse));
 
-        CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(requestConsumer);
+		CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(requestConsumer);
 
-        assertThat(result).isCompletedWithValue(expectedResponse);
-        ArgumentCaptor<Consumer<SendMessageRequest.Builder>> captor =
-                ArgumentCaptor.forClass(Consumer.class);
-        then(mockBatchManager).should().sendMessage(captor.capture());
-        assertThat(captor.getValue()).isEqualTo(requestConsumer);
-    }
+		assertThat(result).isCompletedWithValue(expectedResponse);
+		ArgumentCaptor<Consumer<SendMessageRequest.Builder>> captor = ArgumentCaptor.forClass(Consumer.class);
+		then(mockBatchManager).should().sendMessage(captor.capture());
+		assertThat(captor.getValue()).isEqualTo(requestConsumer);
+	}
 
-    @Test
-    void shouldDelegateReceiveMessageWithRequest() {
-        String queueUrl = "test-queue";
-        String body = "test-body";
+	@Test
+	void shouldDelegateReceiveMessageWithRequest() {
+		String queueUrl = "test-queue";
+		String body = "test-body";
 
-        ReceiveMessageRequest request = ReceiveMessageRequest.builder()
-                .queueUrl(queueUrl)
-                .maxNumberOfMessages(10)
-                .build();
-        Message message = Message.builder()
-                .messageId(UUID.randomUUID().toString())
-                .body(body)
-                .build();
-        ReceiveMessageResponse expectedResponse = ReceiveMessageResponse.builder()
-                .messages(message)
-                .build();
-        given(mockBatchManager.receiveMessage(request))
-                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+		ReceiveMessageRequest request = ReceiveMessageRequest.builder().queueUrl(queueUrl).maxNumberOfMessages(10)
+				.build();
+		Message message = Message.builder().messageId(UUID.randomUUID().toString()).body(body).build();
+		ReceiveMessageResponse expectedResponse = ReceiveMessageResponse.builder().messages(message).build();
+		given(mockBatchManager.receiveMessage(request)).willReturn(CompletableFuture.completedFuture(expectedResponse));
 
-        CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(request);
+		CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(request);
 
-        assertThat(result).isCompletedWithValue(expectedResponse);
-        then(mockBatchManager).should().receiveMessage(request);
-    }
+		assertThat(result).isCompletedWithValue(expectedResponse);
+		then(mockBatchManager).should().receiveMessage(request);
+	}
 
-    @Test
-    void shouldDelegateReceiveMessageWithConsumer() {
-        String queueUrl = "test-queue";
-        String body = "test-body";
+	@Test
+	void shouldDelegateReceiveMessageWithConsumer() {
+		String queueUrl = "test-queue";
+		String body = "test-body";
 
-        Consumer<ReceiveMessageRequest.Builder> requestConsumer = builder ->
-                builder.queueUrl(queueUrl).maxNumberOfMessages(10);
-        Message message = Message.builder()
-                .messageId(UUID.randomUUID().toString())
-                .body(body)
-                .build();
-        ReceiveMessageResponse expectedResponse = ReceiveMessageResponse.builder()
-                .messages(message)
-                .build();
-        given(mockBatchManager.receiveMessage(any(Consumer.class)))
-                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+		Consumer<ReceiveMessageRequest.Builder> requestConsumer = builder -> builder.queueUrl(queueUrl)
+				.maxNumberOfMessages(10);
+		Message message = Message.builder().messageId(UUID.randomUUID().toString()).body(body).build();
+		ReceiveMessageResponse expectedResponse = ReceiveMessageResponse.builder().messages(message).build();
+		given(mockBatchManager.receiveMessage(any(Consumer.class)))
+				.willReturn(CompletableFuture.completedFuture(expectedResponse));
 
-        CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(requestConsumer);
+		CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(requestConsumer);
 
-        assertThat(result).isCompletedWithValue(expectedResponse);
-        ArgumentCaptor<Consumer<ReceiveMessageRequest.Builder>> captor =
-                ArgumentCaptor.forClass(Consumer.class);
-        then(mockBatchManager).should().receiveMessage(captor.capture());
-        assertThat(captor.getValue()).isEqualTo(requestConsumer);
-    }
+		assertThat(result).isCompletedWithValue(expectedResponse);
+		ArgumentCaptor<Consumer<ReceiveMessageRequest.Builder>> captor = ArgumentCaptor.forClass(Consumer.class);
+		then(mockBatchManager).should().receiveMessage(captor.capture());
+		assertThat(captor.getValue()).isEqualTo(requestConsumer);
+	}
 
-    @Test
-    void shouldDelegateDeleteMessageWithRequest() {
-        String queueUrl = "test-queue";
-        String receiptHandle = "test-receipt-handle";
+	@Test
+	void shouldDelegateDeleteMessageWithRequest() {
+		String queueUrl = "test-queue";
+		String receiptHandle = "test-receipt-handle";
 
-        DeleteMessageRequest request = DeleteMessageRequest.builder()
-                .queueUrl(queueUrl)
-                .receiptHandle(receiptHandle)
-                .build();
-        DeleteMessageResponse expectedResponse = DeleteMessageResponse.builder().build();
-        given(mockBatchManager.deleteMessage(request))
-                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+		DeleteMessageRequest request = DeleteMessageRequest.builder().queueUrl(queueUrl).receiptHandle(receiptHandle)
+				.build();
+		DeleteMessageResponse expectedResponse = DeleteMessageResponse.builder().build();
+		given(mockBatchManager.deleteMessage(request)).willReturn(CompletableFuture.completedFuture(expectedResponse));
 
-        CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(request);
+		CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(request);
 
-        assertThat(result).isCompletedWithValue(expectedResponse);
-        then(mockBatchManager).should().deleteMessage(request);
-    }
+		assertThat(result).isCompletedWithValue(expectedResponse);
+		then(mockBatchManager).should().deleteMessage(request);
+	}
 
-    @Test
-    void shouldDelegateDeleteMessageWithConsumer() {
-        String queueUrl = "test-queue";
-        String receiptHandle = "test-receipt-handle";
+	@Test
+	void shouldDelegateDeleteMessageWithConsumer() {
+		String queueUrl = "test-queue";
+		String receiptHandle = "test-receipt-handle";
 
-        Consumer<DeleteMessageRequest.Builder> requestConsumer = builder ->
-                builder.queueUrl(queueUrl).receiptHandle(receiptHandle);
-        DeleteMessageResponse expectedResponse = DeleteMessageResponse.builder().build();
-        given(mockBatchManager.deleteMessage(any(Consumer.class)))
-                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+		Consumer<DeleteMessageRequest.Builder> requestConsumer = builder -> builder.queueUrl(queueUrl)
+				.receiptHandle(receiptHandle);
+		DeleteMessageResponse expectedResponse = DeleteMessageResponse.builder().build();
+		given(mockBatchManager.deleteMessage(any(Consumer.class)))
+				.willReturn(CompletableFuture.completedFuture(expectedResponse));
 
-        CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(requestConsumer);
+		CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(requestConsumer);
 
-        assertThat(result).isCompletedWithValue(expectedResponse);
-        ArgumentCaptor<Consumer<DeleteMessageRequest.Builder>> captor =
-                ArgumentCaptor.forClass(Consumer.class);
-        then(mockBatchManager).should().deleteMessage(captor.capture());
-        assertThat(captor.getValue()).isEqualTo(requestConsumer);
-    }
+		assertThat(result).isCompletedWithValue(expectedResponse);
+		ArgumentCaptor<Consumer<DeleteMessageRequest.Builder>> captor = ArgumentCaptor.forClass(Consumer.class);
+		then(mockBatchManager).should().deleteMessage(captor.capture());
+		assertThat(captor.getValue()).isEqualTo(requestConsumer);
+	}
 
-    @Test
-    void shouldDelegateChangeMessageVisibilityWithRequest() {
-        String queueUrl = "test-queue";
-        String receiptHandle = "test-receipt-handle";
+	@Test
+	void shouldDelegateChangeMessageVisibilityWithRequest() {
+		String queueUrl = "test-queue";
+		String receiptHandle = "test-receipt-handle";
 
-        ChangeMessageVisibilityRequest request = ChangeMessageVisibilityRequest.builder()
-                .queueUrl(queueUrl)
-                .receiptHandle(receiptHandle)
-                .visibilityTimeout(30)
-                .build();
-        ChangeMessageVisibilityResponse expectedResponse = ChangeMessageVisibilityResponse.builder().build();
-        given(mockBatchManager.changeMessageVisibility(request))
-                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+		ChangeMessageVisibilityRequest request = ChangeMessageVisibilityRequest.builder().queueUrl(queueUrl)
+				.receiptHandle(receiptHandle).visibilityTimeout(30).build();
+		ChangeMessageVisibilityResponse expectedResponse = ChangeMessageVisibilityResponse.builder().build();
+		given(mockBatchManager.changeMessageVisibility(request))
+				.willReturn(CompletableFuture.completedFuture(expectedResponse));
 
-        CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter.changeMessageVisibility(request);
+		CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter.changeMessageVisibility(request);
 
-        assertThat(result).isCompletedWithValue(expectedResponse);
-        then(mockBatchManager).should().changeMessageVisibility(request);
-    }
+		assertThat(result).isCompletedWithValue(expectedResponse);
+		then(mockBatchManager).should().changeMessageVisibility(request);
+	}
 
-    @Test
-    void shouldDelegateChangeMessageVisibilityWithConsumer() {
-        String queueUrl = "test-queue";
-        String receiptHandle = "test-receipt-handle";
+	@Test
+	void shouldDelegateChangeMessageVisibilityWithConsumer() {
+		String queueUrl = "test-queue";
+		String receiptHandle = "test-receipt-handle";
 
-        Consumer<ChangeMessageVisibilityRequest.Builder> requestConsumer = builder ->
-                builder.queueUrl(queueUrl).receiptHandle(receiptHandle).visibilityTimeout(30);
-        ChangeMessageVisibilityResponse expectedResponse = ChangeMessageVisibilityResponse.builder().build();
-        given(mockBatchManager.changeMessageVisibility(any(Consumer.class)))
-                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+		Consumer<ChangeMessageVisibilityRequest.Builder> requestConsumer = builder -> builder.queueUrl(queueUrl)
+				.receiptHandle(receiptHandle).visibilityTimeout(30);
+		ChangeMessageVisibilityResponse expectedResponse = ChangeMessageVisibilityResponse.builder().build();
+		given(mockBatchManager.changeMessageVisibility(any(Consumer.class)))
+				.willReturn(CompletableFuture.completedFuture(expectedResponse));
 
-        CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter.changeMessageVisibility(requestConsumer);
+		CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter
+				.changeMessageVisibility(requestConsumer);
 
-        assertThat(result).isCompletedWithValue(expectedResponse);
-        ArgumentCaptor<Consumer<ChangeMessageVisibilityRequest.Builder>> captor =
-                ArgumentCaptor.forClass(Consumer.class);
-        then(mockBatchManager).should().changeMessageVisibility(captor.capture());
-        assertThat(captor.getValue()).isEqualTo(requestConsumer);
-    }
+		assertThat(result).isCompletedWithValue(expectedResponse);
+		ArgumentCaptor<Consumer<ChangeMessageVisibilityRequest.Builder>> captor = ArgumentCaptor
+				.forClass(Consumer.class);
+		then(mockBatchManager).should().changeMessageVisibility(captor.capture());
+		assertThat(captor.getValue()).isEqualTo(requestConsumer);
+	}
 
-    @Test
-    void shouldHandleExceptionalCompletionInSendMessage() {
-        String queueUrl = "test-queue";
-        String body = "test-message";
+	@Test
+	void shouldHandleExceptionalCompletionInSendMessage() {
+		String queueUrl = "test-queue";
+		String body = "test-message";
 
-        SendMessageRequest request = SendMessageRequest.builder()
-                .queueUrl(queueUrl)
-                .messageBody(body)
-                .build();
-        RuntimeException exception = new RuntimeException("Batch manager error");
-        CompletableFuture<SendMessageResponse> failedFuture = new CompletableFuture<>();
-        failedFuture.completeExceptionally(exception);
-        given(mockBatchManager.sendMessage(request)).willReturn(failedFuture);
+		SendMessageRequest request = SendMessageRequest.builder().queueUrl(queueUrl).messageBody(body).build();
+		RuntimeException exception = new RuntimeException("Batch manager error");
+		CompletableFuture<SendMessageResponse> failedFuture = new CompletableFuture<>();
+		failedFuture.completeExceptionally(exception);
+		given(mockBatchManager.sendMessage(request)).willReturn(failedFuture);
 
-        CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(request);
+		CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(request);
 
-        assertThat(result).isCompletedExceptionally();
-        then(mockBatchManager).should().sendMessage(request);
-    }
+		assertThat(result).isCompletedExceptionally();
+		then(mockBatchManager).should().sendMessage(request);
+	}
 
-    @Test
-    void shouldHandleExceptionalCompletionInReceiveMessage() {
-        String queueUrl = "test-queue";
+	@Test
+	void shouldHandleExceptionalCompletionInReceiveMessage() {
+		String queueUrl = "test-queue";
 
-        ReceiveMessageRequest request = ReceiveMessageRequest.builder()
-                .queueUrl(queueUrl)
-                .build();
-        RuntimeException exception = new RuntimeException("Batch manager error");
-        CompletableFuture<ReceiveMessageResponse> failedFuture = new CompletableFuture<>();
-        failedFuture.completeExceptionally(exception);
-        given(mockBatchManager.receiveMessage(request)).willReturn(failedFuture);
+		ReceiveMessageRequest request = ReceiveMessageRequest.builder().queueUrl(queueUrl).build();
+		RuntimeException exception = new RuntimeException("Batch manager error");
+		CompletableFuture<ReceiveMessageResponse> failedFuture = new CompletableFuture<>();
+		failedFuture.completeExceptionally(exception);
+		given(mockBatchManager.receiveMessage(request)).willReturn(failedFuture);
 
-        CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(request);
+		CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(request);
 
-        assertThat(result).isCompletedExceptionally();
-        then(mockBatchManager).should().receiveMessage(request);
-    }
+		assertThat(result).isCompletedExceptionally();
+		then(mockBatchManager).should().receiveMessage(request);
+	}
 
-    @Test
-    void shouldHandleExceptionalCompletionInDeleteMessage() {
-        String queueUrl = "test-queue";
-        String receiptHandle = "test-receipt-handle";
+	@Test
+	void shouldHandleExceptionalCompletionInDeleteMessage() {
+		String queueUrl = "test-queue";
+		String receiptHandle = "test-receipt-handle";
 
-        DeleteMessageRequest request = DeleteMessageRequest.builder()
-                .queueUrl(queueUrl)
-                .receiptHandle(receiptHandle)
-                .build();
-        RuntimeException exception = new RuntimeException("Batch manager error");
-        CompletableFuture<DeleteMessageResponse> failedFuture = new CompletableFuture<>();
-        failedFuture.completeExceptionally(exception);
-        given(mockBatchManager.deleteMessage(request)).willReturn(failedFuture);
+		DeleteMessageRequest request = DeleteMessageRequest.builder().queueUrl(queueUrl).receiptHandle(receiptHandle)
+				.build();
+		RuntimeException exception = new RuntimeException("Batch manager error");
+		CompletableFuture<DeleteMessageResponse> failedFuture = new CompletableFuture<>();
+		failedFuture.completeExceptionally(exception);
+		given(mockBatchManager.deleteMessage(request)).willReturn(failedFuture);
 
-        CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(request);
+		CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(request);
 
-        assertThat(result).isCompletedExceptionally();
-        then(mockBatchManager).should().deleteMessage(request);
-    }
+		assertThat(result).isCompletedExceptionally();
+		then(mockBatchManager).should().deleteMessage(request);
+	}
 
-    @Test
-    void shouldHandleExceptionalCompletionInChangeMessageVisibility() {
-        String queueUrl = "test-queue";
-        String receiptHandle = "test-receipt-handle";
+	@Test
+	void shouldHandleExceptionalCompletionInChangeMessageVisibility() {
+		String queueUrl = "test-queue";
+		String receiptHandle = "test-receipt-handle";
 
-        ChangeMessageVisibilityRequest request = ChangeMessageVisibilityRequest.builder()
-                .queueUrl(queueUrl)
-                .receiptHandle(receiptHandle)
-                .visibilityTimeout(30)
-                .build();
-        RuntimeException exception = new RuntimeException("Batch manager error");
-        CompletableFuture<ChangeMessageVisibilityResponse> failedFuture = new CompletableFuture<>();
-        failedFuture.completeExceptionally(exception);
-        given(mockBatchManager.changeMessageVisibility(request)).willReturn(failedFuture);
+		ChangeMessageVisibilityRequest request = ChangeMessageVisibilityRequest.builder().queueUrl(queueUrl)
+				.receiptHandle(receiptHandle).visibilityTimeout(30).build();
+		RuntimeException exception = new RuntimeException("Batch manager error");
+		CompletableFuture<ChangeMessageVisibilityResponse> failedFuture = new CompletableFuture<>();
+		failedFuture.completeExceptionally(exception);
+		given(mockBatchManager.changeMessageVisibility(request)).willReturn(failedFuture);
 
-        CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter.changeMessageVisibility(request);
+		CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter.changeMessageVisibility(request);
 
-        assertThat(result).isCompletedExceptionally();
-        then(mockBatchManager).should().changeMessageVisibility(request);
-    }
+		assertThat(result).isCompletedExceptionally();
+		then(mockBatchManager).should().changeMessageVisibility(request);
+	}
 }

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapterTests.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.awspring.cloud.sqs.operations;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.batchmanager.SqsAsyncBatchManager;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author khc41
+ */
+@ExtendWith(MockitoExtension.class)
+class BatchingSqsClientAdapterTests {
+    SqsAsyncBatchManager mockBatchManager;
+
+    BatchingSqsClientAdapter mockAdapter;
+
+    @BeforeEach
+    void beforeEach() {
+        mockBatchManager = mock(SqsAsyncBatchManager.class);
+        mockAdapter = new BatchingSqsClientAdapter(mockBatchManager);
+    }
+
+    @Test
+    void shouldReturnCorrectServiceName() {
+        String serviceName = mockAdapter.serviceName();
+        assertThat(serviceName).isEqualTo(SqsAsyncClient.SERVICE_NAME);
+    }
+
+    @Test
+    void shouldDelegateBatchManagerClose() {
+        mockAdapter.close();
+        then(mockBatchManager).should().close();
+    }
+
+    @Test
+    void shouldDelegateSendMessageWithRequest() {
+        String queueUrl = "test-queue";
+        String messageBody = "test-message";
+
+        SendMessageRequest request = SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(messageBody)
+                .build();
+        SendMessageResponse expectedResponse = SendMessageResponse.builder()
+                .messageId(UUID.randomUUID().toString())
+                .build();
+        given(mockBatchManager.sendMessage(request))
+                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(request);
+
+        assertThat(result).isCompletedWithValue(expectedResponse);
+        then(mockBatchManager).should().sendMessage(request);
+    }
+
+    @Test
+    void shouldDelegateSendMessageWithConsumer() {
+        String queueUrl = "test-queue";
+        String messageBody = "test-message";
+
+        Consumer<SendMessageRequest.Builder> requestConsumer = builder ->
+                builder.queueUrl(queueUrl).messageBody(messageBody);
+        SendMessageResponse expectedResponse = SendMessageResponse.builder()
+                .messageId(UUID.randomUUID().toString())
+                .build();
+        given(mockBatchManager.sendMessage(any(Consumer.class)))
+                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(requestConsumer);
+
+        assertThat(result).isCompletedWithValue(expectedResponse);
+        ArgumentCaptor<Consumer<SendMessageRequest.Builder>> captor =
+                ArgumentCaptor.forClass(Consumer.class);
+        then(mockBatchManager).should().sendMessage(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(requestConsumer);
+    }
+
+    @Test
+    void shouldDelegateReceiveMessageWithRequest() {
+        String queueUrl = "test-queue";
+        String body = "test-body";
+
+        ReceiveMessageRequest request = ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .maxNumberOfMessages(10)
+                .build();
+        Message message = Message.builder()
+                .messageId(UUID.randomUUID().toString())
+                .body(body)
+                .build();
+        ReceiveMessageResponse expectedResponse = ReceiveMessageResponse.builder()
+                .messages(message)
+                .build();
+        given(mockBatchManager.receiveMessage(request))
+                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(request);
+
+        assertThat(result).isCompletedWithValue(expectedResponse);
+        then(mockBatchManager).should().receiveMessage(request);
+    }
+
+    @Test
+    void shouldDelegateReceiveMessageWithConsumer() {
+        String queueUrl = "test-queue";
+        String body = "test-body";
+
+        Consumer<ReceiveMessageRequest.Builder> requestConsumer = builder ->
+                builder.queueUrl(queueUrl).maxNumberOfMessages(10);
+        Message message = Message.builder()
+                .messageId(UUID.randomUUID().toString())
+                .body(body)
+                .build();
+        ReceiveMessageResponse expectedResponse = ReceiveMessageResponse.builder()
+                .messages(message)
+                .build();
+        given(mockBatchManager.receiveMessage(any(Consumer.class)))
+                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(requestConsumer);
+
+        assertThat(result).isCompletedWithValue(expectedResponse);
+        ArgumentCaptor<Consumer<ReceiveMessageRequest.Builder>> captor =
+                ArgumentCaptor.forClass(Consumer.class);
+        then(mockBatchManager).should().receiveMessage(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(requestConsumer);
+    }
+
+    @Test
+    void shouldDelegateDeleteMessageWithRequest() {
+        String queueUrl = "test-queue";
+        String receiptHandle = "test-receipt-handle";
+
+        DeleteMessageRequest request = DeleteMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .build();
+        DeleteMessageResponse expectedResponse = DeleteMessageResponse.builder().build();
+        given(mockBatchManager.deleteMessage(request))
+                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(request);
+
+        assertThat(result).isCompletedWithValue(expectedResponse);
+        then(mockBatchManager).should().deleteMessage(request);
+    }
+
+    @Test
+    void shouldDelegateDeleteMessageWithConsumer() {
+        String queueUrl = "test-queue";
+        String receiptHandle = "test-receipt-handle";
+
+        Consumer<DeleteMessageRequest.Builder> requestConsumer = builder ->
+                builder.queueUrl(queueUrl).receiptHandle(receiptHandle);
+        DeleteMessageResponse expectedResponse = DeleteMessageResponse.builder().build();
+        given(mockBatchManager.deleteMessage(any(Consumer.class)))
+                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(requestConsumer);
+
+        assertThat(result).isCompletedWithValue(expectedResponse);
+        ArgumentCaptor<Consumer<DeleteMessageRequest.Builder>> captor =
+                ArgumentCaptor.forClass(Consumer.class);
+        then(mockBatchManager).should().deleteMessage(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(requestConsumer);
+    }
+
+    @Test
+    void shouldDelegateChangeMessageVisibilityWithRequest() {
+        String queueUrl = "test-queue";
+        String receiptHandle = "test-receipt-handle";
+
+        ChangeMessageVisibilityRequest request = ChangeMessageVisibilityRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .visibilityTimeout(30)
+                .build();
+        ChangeMessageVisibilityResponse expectedResponse = ChangeMessageVisibilityResponse.builder().build();
+        given(mockBatchManager.changeMessageVisibility(request))
+                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter.changeMessageVisibility(request);
+
+        assertThat(result).isCompletedWithValue(expectedResponse);
+        then(mockBatchManager).should().changeMessageVisibility(request);
+    }
+
+    @Test
+    void shouldDelegateChangeMessageVisibilityWithConsumer() {
+        String queueUrl = "test-queue";
+        String receiptHandle = "test-receipt-handle";
+
+        Consumer<ChangeMessageVisibilityRequest.Builder> requestConsumer = builder ->
+                builder.queueUrl(queueUrl).receiptHandle(receiptHandle).visibilityTimeout(30);
+        ChangeMessageVisibilityResponse expectedResponse = ChangeMessageVisibilityResponse.builder().build();
+        given(mockBatchManager.changeMessageVisibility(any(Consumer.class)))
+                .willReturn(CompletableFuture.completedFuture(expectedResponse));
+
+        CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter.changeMessageVisibility(requestConsumer);
+
+        assertThat(result).isCompletedWithValue(expectedResponse);
+        ArgumentCaptor<Consumer<ChangeMessageVisibilityRequest.Builder>> captor =
+                ArgumentCaptor.forClass(Consumer.class);
+        then(mockBatchManager).should().changeMessageVisibility(captor.capture());
+        assertThat(captor.getValue()).isEqualTo(requestConsumer);
+    }
+
+    @Test
+    void shouldHandleExceptionalCompletionInSendMessage() {
+        String queueUrl = "test-queue";
+        String body = "test-message";
+
+        SendMessageRequest request = SendMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .messageBody(body)
+                .build();
+        RuntimeException exception = new RuntimeException("Batch manager error");
+        CompletableFuture<SendMessageResponse> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(exception);
+        given(mockBatchManager.sendMessage(request)).willReturn(failedFuture);
+
+        CompletableFuture<SendMessageResponse> result = mockAdapter.sendMessage(request);
+
+        assertThat(result).isCompletedExceptionally();
+        then(mockBatchManager).should().sendMessage(request);
+    }
+
+    @Test
+    void shouldHandleExceptionalCompletionInReceiveMessage() {
+        String queueUrl = "test-queue";
+
+        ReceiveMessageRequest request = ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .build();
+        RuntimeException exception = new RuntimeException("Batch manager error");
+        CompletableFuture<ReceiveMessageResponse> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(exception);
+        given(mockBatchManager.receiveMessage(request)).willReturn(failedFuture);
+
+        CompletableFuture<ReceiveMessageResponse> result = mockAdapter.receiveMessage(request);
+
+        assertThat(result).isCompletedExceptionally();
+        then(mockBatchManager).should().receiveMessage(request);
+    }
+
+    @Test
+    void shouldHandleExceptionalCompletionInDeleteMessage() {
+        String queueUrl = "test-queue";
+        String receiptHandle = "test-receipt-handle";
+
+        DeleteMessageRequest request = DeleteMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .build();
+        RuntimeException exception = new RuntimeException("Batch manager error");
+        CompletableFuture<DeleteMessageResponse> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(exception);
+        given(mockBatchManager.deleteMessage(request)).willReturn(failedFuture);
+
+        CompletableFuture<DeleteMessageResponse> result = mockAdapter.deleteMessage(request);
+
+        assertThat(result).isCompletedExceptionally();
+        then(mockBatchManager).should().deleteMessage(request);
+    }
+
+    @Test
+    void shouldHandleExceptionalCompletionInChangeMessageVisibility() {
+        String queueUrl = "test-queue";
+        String receiptHandle = "test-receipt-handle";
+
+        ChangeMessageVisibilityRequest request = ChangeMessageVisibilityRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .visibilityTimeout(30)
+                .build();
+        RuntimeException exception = new RuntimeException("Batch manager error");
+        CompletableFuture<ChangeMessageVisibilityResponse> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(exception);
+        given(mockBatchManager.changeMessageVisibility(request)).willReturn(failedFuture);
+
+        CompletableFuture<ChangeMessageVisibilityResponse> result = mockAdapter.changeMessageVisibility(request);
+
+        assertThat(result).isCompletedExceptionally();
+        then(mockBatchManager).should().changeMessageVisibility(request);
+    }
+}

--- a/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapterTests.java
+++ b/spring-cloud-aws-sqs/src/test/java/io/awspring/cloud/sqs/operations/BatchingSqsClientAdapterTests.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -47,6 +48,13 @@ class BatchingSqsClientAdapterTests {
     void beforeEach() {
         mockBatchManager = mock(SqsAsyncBatchManager.class);
         mockAdapter = new BatchingSqsClientAdapter(mockBatchManager);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenBatchManagerIsNull() {
+        assertThatThrownBy(() -> new BatchingSqsClientAdapter(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("batchManager cannot be null");
     }
 
     @Test


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
Added automatic SQS batching support using AWS SDK's SqsAsyncBatchManager.

This feature enables automatic request batching for SQS operations to improve performance and reduce AWS API calls. When enabled, Spring Cloud AWS automatically wraps the `SqsAsyncClient` with a `BatchingSqsClientAdapter` that uses `SqsAsyncBatchManager` internally.

**Key Features:**
- Automatic batching for `sendMessage`, `receiveMessage`, `deleteMessage`, and `changeMessageVisibility` operations
- Configurable batch size, frequency, and timeout settings
- Full Spring Boot auto-configuration support
- Transparent integration with existing `SqsTemplate` and `@SqsListener` code
- Smart attribute handling to avoid AWS SDK batching bypass

**Configuration Example:**
```properties
spring.cloud.aws.sqs.batch.enabled=true
spring.cloud.aws.sqs.batch.max-number-of-messages=10
spring.cloud.aws.sqs.batch.send-batch-frequency=PT0.2S
```

**Important:** Operations are processed asynchronously. Applications should handle returned `CompletableFuture` objects to detect actual transmission errors.


## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
AWS SDK 2.28.0+ introduced automatic request batching capabilities that can significantly improve SQS performance and reduce costs by combining multiple API calls into fewer requests.

Previously, users had to manually implement batching logic or use explicit batch operations. This change enables declarative batching at the configuration level, providing:

- **Improved performance**: Reduced network overhead and latency
- **Cost reduction**: Fewer API calls mean lower AWS charges  
- **Better resource utilization**: More efficient use of network and AWS resources
- **Zero code changes**: Existing applications work without modification

This addresses the community request for supporting AWS SDK's new automatic batching feature in Spring Cloud AWS.


## :green_heart: How did you test it?
**Unit Tests:**
- `BatchingSqsClientAdapterTests`: Comprehensive testing of all adapter methods with mock SqsAsyncBatchManager
- Verified proper delegation of all SQS operations and error handling

**Integration Tests:**  
- `BatchingSqsClientAdapterIntegrationTests`: Real SQS environment testing with LocalStack
- Verified actual message sending, receiving, deleting, and visibility changes
- Tested batching efficiency with multiple concurrent operations

**Auto-Configuration Tests:**
- Extended `SqsAutoConfigurationTest` with comprehensive batch configuration testing
- Verified conditional bean creation based on `spring.cloud.aws.sqs.batch.enabled`
- Tested all configuration properties mapping and validation


## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] I updated reference documentation to reflect the change
- [x] All tests passing
- [x] No breaking changes


## :crystal_ball: Next steps
This implementation provides full support for AWS SDK's automatic batching capabilities. Future enhancements could include:

- Metrics and monitoring integration for batch performance
- Advanced batching strategies based on message types
- Enhanced observability for batching operations

**Related AWS SDK Documentation**: [Use automatic request batching for Amazon SQS](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/examples-sqs-batch.html)